### PR TITLE
small interface refactor

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -8,18 +8,30 @@ import (
 
 const defaultNamespace = "clue_ns_default"
 
-// outer map tracks namespaces
-// inner map tracks key/value pairs
-type namespacedClues map[string]map[string]any
+type values map[string]any
 
-func newClueMap() namespacedClues {
-	return namespacedClues{defaultNamespace: map[string]any{}}
+func (vs values) Slice() []any {
+	s := make([]any, 0, 2*len(vs))
+
+	for k, v := range vs {
+		s = append(s, k, v)
+	}
+
+	return s
 }
 
-func (nc namespacedClues) namespace(name string) map[string]any {
+// outer map tracks namespaces
+// inner map tracks key/value pairs
+type namespacedClues map[string]values
+
+func newClueMap() namespacedClues {
+	return namespacedClues{defaultNamespace: values{}}
+}
+
+func (nc namespacedClues) namespace(name string) values {
 	ns, ok := nc[name]
 	if !ok {
-		ns = map[string]any{}
+		ns = values{}
 		nc[name] = ns
 	}
 
@@ -129,38 +141,14 @@ func AddMapTo[K comparable, V any](ctx context.Context, namespace string, m map[
 	return set(ctx, nc)
 }
 
-// Values returns the map of values in the default namespace.
-func Values(ctx context.Context) map[string]any {
+// In returns the map of values in the default namespace.
+func In(ctx context.Context) values {
 	nc := from(ctx)
 	return nc.namespace(defaultNamespace)
 }
 
-// Namespace returns the map of values in the given namespace.
-func Namespace(ctx context.Context, namespace string) map[string]any {
+// InNamespace returns the map of values in the given namespace.
+func InNamespace(ctx context.Context, namespace string) values {
 	nc := from(ctx)
 	return nc.namespace(namespace)
-}
-
-func asSlice(ns map[string]any) []any {
-	s := make([]any, 0, 2*len(ns))
-
-	for k, v := range ns {
-		s = append(s, k, v)
-	}
-
-	return s
-}
-
-// Slice returns all the values in the default namespace as a slice
-// of alternating key, value pairs.
-func Slice(ctx context.Context) []any {
-	ns := Values(ctx)
-	return asSlice(ns)
-}
-
-// NameSlice returns all the values in the given namespace as a slice
-// of alternating key, value pairs.
-func NameSlice(ctx context.Context, namespace string) []any {
-	ns := Namespace(ctx, namespace)
-	return asSlice(ns)
 }

--- a/clues_test.go
+++ b/clues_test.go
@@ -95,10 +95,12 @@ func assert(
 	eM, eMns msa,
 	eS, eSns sa,
 ) {
-	eM.equals(t, clues.Values(ctx))
-	eMns.equals(t, clues.Namespace(ctx, ns))
-	eS.equals(t, clues.Slice(ctx))
-	eSns.equals(t, clues.NameSlice(ctx, ns))
+	vs := clues.In(ctx)
+	nvs := clues.InNamespace(ctx, ns)
+	eM.equals(t, vs)
+	eMns.equals(t, nvs)
+	eS.equals(t, vs.Slice())
+	eSns.equals(t, nvs.Slice())
 }
 
 type testCtx struct{}
@@ -118,12 +120,12 @@ func TestAdd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Values(ctx))
+			check.equals(t, clues.In(ctx))
 
 			for _, kv := range test.kvs {
 				ctx = clues.Add(ctx, kv[0], kv[1])
 				check[kv[0]] = kv[1]
-				check.equals(t, clues.Values(ctx))
+				check.equals(t, clues.In(ctx))
 			}
 
 			assert(
@@ -150,12 +152,12 @@ func TestAddAll(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Values(ctx))
+			check.equals(t, clues.In(ctx))
 
 			for _, kv := range test.kvs {
 				ctx = clues.AddAll(ctx, kv[0], kv[1])
 				check[kv[0]] = kv[1]
-				check.equals(t, clues.Values(ctx))
+				check.equals(t, clues.In(ctx))
 			}
 
 			assert(
@@ -182,14 +184,14 @@ func TestAddMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Values(ctx))
+			check.equals(t, clues.In(ctx))
 
 			for _, m := range test.ms {
 				ctx = clues.AddMap(ctx, m)
 				for k, v := range m {
 					check[k] = v
 				}
-				check.equals(t, clues.Values(ctx))
+				check.equals(t, clues.In(ctx))
 			}
 
 			assert(
@@ -215,12 +217,12 @@ func TestAddTo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Namespace(ctx, "ns"))
+			check.equals(t, clues.InNamespace(ctx, "ns"))
 
 			for _, kv := range test.kvs {
 				ctx = clues.AddTo(ctx, "ns", kv[0], kv[1])
 				check[kv[0]] = kv[1]
-				check.equals(t, clues.Namespace(ctx, "ns"))
+				check.equals(t, clues.InNamespace(ctx, "ns"))
 			}
 
 			assert(
@@ -247,12 +249,12 @@ func TestAddAllTo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Namespace(ctx, "ns"))
+			check.equals(t, clues.InNamespace(ctx, "ns"))
 
 			for _, kv := range test.kvs {
 				ctx = clues.AddAllTo(ctx, "ns", kv[0], kv[1])
 				check[kv[0]] = kv[1]
-				check.equals(t, clues.Namespace(ctx, "ns"))
+				check.equals(t, clues.InNamespace(ctx, "ns"))
 			}
 
 			assert(
@@ -279,14 +281,14 @@ func TestAddMapTo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.WithValue(context.Background(), testCtx{}, "instance")
 			check := msa{}
-			check.equals(t, clues.Namespace(ctx, "ns"))
+			check.equals(t, clues.InNamespace(ctx, "ns"))
 
 			for _, m := range test.ms {
 				ctx = clues.AddMapTo(ctx, "ns", m)
 				for k, v := range m {
 					check[k] = v
 				}
-				check.equals(t, clues.Namespace(ctx, "ns"))
+				check.equals(t, clues.InNamespace(ctx, "ns"))
 			}
 
 			assert(

--- a/err_test.go
+++ b/err_test.go
@@ -109,7 +109,7 @@ func TestWith(t *testing.T) {
 			for _, kv := range test.with {
 				err.With(kv[0], kv[1])
 			}
-			test.expect.equals(t, clues.ErrValues(err))
+			test.expect.equals(t, clues.InErr(err))
 			test.expect.equals(t, err.Values())
 		})
 	}
@@ -146,7 +146,7 @@ func TestWithAll(t *testing.T) {
 			for _, kv := range test.with {
 				err.WithAll(kv...)
 			}
-			test.expect.equals(t, clues.ErrValues(err))
+			test.expect.equals(t, clues.InErr(err))
 			test.expect.equals(t, err.Values())
 		})
 	}
@@ -181,7 +181,7 @@ func TestWithMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := clues.WithMap(test.initial, test.kv)
 			err.WithMap(test.with)
-			test.expect.equals(t, clues.ErrValues(err))
+			test.expect.equals(t, clues.InErr(err))
 			test.expect.equals(t, err.Values())
 		})
 	}
@@ -219,7 +219,7 @@ func TestWithClues(t *testing.T) {
 			tctx := clues.AddMap(ctx, test.kv)
 			err := clues.WithClues(test.initial, tctx)
 			err.WithMap(test.with)
-			test.expect.equals(t, clues.ErrValues(err))
+			test.expect.equals(t, clues.InErr(err))
 			test.expect.equals(t, err.Values())
 		})
 	}
@@ -461,7 +461,7 @@ func TestErrValues_stacks(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			vs := clues.ErrValues(test.err)
+			vs := clues.InErr(test.err)
 			test.expect.equals(t, vs)
 		})
 	}


### PR DESCRIPTION
Removes clues.Slice() in place of clues.Values().Slice(). This cuts down on interface bloat, and provies the error side of the package to provide slices without also adding a set of err.values-to-slice interfaces.

Also renames Values to In, as the interface of `clues.In()` reads better than `clues.Values()`.