### PR TITLE
add secrets handling

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -1,0 +1,106 @@
+package clues
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+type hashAlg int
+
+const (
+	SHA256 hashAlg = iota
+	HMAC_SHA256
+	Plaintext
+)
+
+var hashingAlgorithm = HMAC_SHA256
+
+type Concealer interface {
+	Conceal() string
+}
+
+type secret struct {
+	s string
+	v any
+	h string
+}
+
+func (s secret) String() string  { return s.s }
+func (s secret) Conceal() string { return s.h }
+
+// Mask embeds the value in a clues. secret where the
+// Conceal() call always returns a flat string: "***"
+func Mask(a any) secret {
+	str := marshal(a)
+
+	return secret{
+		s: str,
+		v: a,
+		h: "***",
+	}
+}
+
+// Hide embeds the value in a clues. secret where the
+// Conceal() call contains a truncated hash of value.
+// The hash function defaults to SHA256, but can be
+// changed through configuration.
+func Hide(a any) secret {
+	str := marshal(a)
+
+	return secret{
+		s: str,
+		v: a,
+		h: Conceal(hashingAlgorithm, str),
+	}
+}
+
+// HideAll is a quality-of-life wrapper for transforming
+// multiple values to clues.secrete structs.
+func HideAll(a ...any) []secret {
+	sl := make([]secret, 0, len(a))
+
+	for _, v := range a {
+		sl = append(sl, Hide(v))
+	}
+
+	return sl
+}
+
+// Conceal runs one of clues' hashing algorithms on
+// the provided string.
+func Conceal(alg hashAlg, s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+
+	switch alg {
+	case HMAC_SHA256:
+		return hashHmacSha256(s)
+
+	case Plaintext:
+		return s
+
+	default:
+		return hashSha256(s)
+	}
+}
+
+func hashHmacSha256(s string) string {
+	var (
+		// need to set up key establishment.
+		key = []byte("TODO-rjjATxL6KRlCaDGyRpIc3T4PUYAUXIz8")
+		sig = hmac.New(sha256.New, key)
+	)
+
+	sig.Write([]byte(s))
+
+	return hex.EncodeToString(sig.Sum(nil))[:16]
+}
+
+func hashSha256(s string) string {
+	h := sha256.New()
+	h.Write([]byte(s))
+
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}

--- a/secrets.go
+++ b/secrets.go
@@ -14,6 +14,8 @@ const (
 	Plaintext
 )
 
+const hashTruncateLen = 16
+
 var hashingAlgorithm = HMAC_SHA256
 
 type Concealer interface {
@@ -29,7 +31,7 @@ type secret struct {
 func (s secret) String() string  { return s.s }
 func (s secret) Conceal() string { return s.h }
 
-// Mask embeds the value in a clues. secret where the
+// Mask embeds the value in a secret struct where the
 // Conceal() call always returns a flat string: "***"
 func Mask(a any) secret {
 	str := marshal(a)
@@ -41,7 +43,7 @@ func Mask(a any) secret {
 	}
 }
 
-// Hide embeds the value in a clues. secret where the
+// Hide embeds the value in a secret struct where the
 // Conceal() call contains a truncated hash of value.
 // The hash function defaults to SHA256, but can be
 // changed through configuration.
@@ -56,7 +58,7 @@ func Hide(a any) secret {
 }
 
 // HideAll is a quality-of-life wrapper for transforming
-// multiple values to clues.secrete structs.
+// multiple values to secret structs.
 func HideAll(a ...any) []secret {
 	sl := make([]secret, 0, len(a))
 
@@ -95,12 +97,12 @@ func hashHmacSha256(s string) string {
 
 	sig.Write([]byte(s))
 
-	return hex.EncodeToString(sig.Sum(nil))[:16]
+	return hex.EncodeToString(sig.Sum(nil))[:hashTruncateLen]
 }
 
 func hashSha256(s string) string {
 	h := sha256.New()
 	h.Write([]byte(s))
 
-	return hex.EncodeToString(h.Sum(nil))[:16]
+	return hex.EncodeToString(h.Sum(nil))[:hashTruncateLen]
 }

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,184 @@
+package clues
+
+import "testing"
+
+type mockStringer struct {
+	s string
+}
+
+func (ms mockStringer) String() string { return "{s:" + ms.s + "}" }
+
+func TestConceal(t *testing.T) {
+	input := "brunhaldi"
+
+	table := []struct {
+		name   string
+		alg    hashAlg
+		expect string
+	}{
+		{
+			name:   "plainText",
+			alg:    Plaintext,
+			expect: input,
+		},
+		{
+			name:   "sha256",
+			alg:    SHA256,
+			expect: "5fa99f4a1bb5f651",
+		},
+		{
+			name:   "hmac_sha256",
+			alg:    HMAC_SHA256,
+			expect: "f9ee6adbbdbb65bf",
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			result := Conceal(test.alg, input)
+			if result != test.expect {
+				t.Errorf(`expected hash result "%s", got "%s"`, test.expect, result)
+			}
+		})
+	}
+}
+
+func TestMask(t *testing.T) {
+	table := []struct {
+		name   string
+		input  any
+		expect string
+	}{
+		{
+			name:   "string",
+			input:  "fnords",
+			expect: "fnords",
+		},
+		{
+			name:   "stringer",
+			input:  mockStringer{"fnords"},
+			expect: "{s:fnords}",
+		},
+		{
+			name:   "map",
+			input:  map[string]string{"fnords": "smarf"},
+			expect: `{"fnords":"smarf"}`,
+		},
+		{
+			name:   "nil",
+			input:  nil,
+			expect: ``,
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			m := Mask(test.input)
+			if m.Conceal() != "***" {
+				t.Errorf(`expected Conceal() result "***", got "%s"`, m.Conceal())
+			}
+			if m.String() != test.expect {
+				t.Errorf(`expected String() result "%s", got "%s"`, test.expect, m.String())
+			}
+		})
+	}
+}
+
+func TestHide(t *testing.T) {
+	table := []struct {
+		name       string
+		input      any
+		expectHash string
+		expectStr  string
+	}{
+		{
+			name:       "string",
+			input:      "fnords",
+			expectHash: "1c8deb0df69dd549",
+			expectStr:  "fnords",
+		},
+		{
+			name:       "int",
+			input:      1,
+			expectHash: "1f81f27cdeeb75f0",
+			expectStr:  "1",
+		},
+		{
+			name:       "stringer",
+			input:      mockStringer{"fnords"},
+			expectHash: "528771b0ce994710",
+			expectStr:  "{s:fnords}",
+		},
+		{
+			name:       "map",
+			input:      map[string]string{"fnords": "smarf"},
+			expectHash: "b1678c6da072f896",
+			expectStr:  `{"fnords":"smarf"}`,
+		},
+		{
+			name:       "nil",
+			input:      nil,
+			expectHash: "",
+			expectStr:  ``,
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			h := Hide(test.input)
+			if h.Conceal() != test.expectHash {
+				t.Errorf(`expected Conceal() result "%s", got "%s"`, test.expectHash, h.Conceal())
+			}
+			if h.String() != test.expectStr {
+				t.Errorf(`expected String() result "%s", got "%s"`, test.expectStr, h.String())
+			}
+		})
+	}
+}
+
+func TestHideAll(t *testing.T) {
+	table := []struct {
+		name       string
+		input      []any
+		expectHash []string
+		expectStr  []string
+	}{
+		{
+			name:       "string, int",
+			input:      []any{"fnords", 1},
+			expectHash: []string{"1c8deb0df69dd549", "1f81f27cdeeb75f0"},
+			expectStr:  []string{"fnords", "1"},
+		},
+		{
+			name:       "stringer",
+			input:      []any{mockStringer{"fnords"}, mockStringer{"smarf"}},
+			expectHash: []string{"528771b0ce994710", "8edc7a58f4c9a252"},
+			expectStr:  []string{"{s:fnords}", "{s:smarf}"},
+		},
+		{
+			name:       "map",
+			input:      []any{map[string]string{"fnords": "smarf"}},
+			expectHash: []string{"b1678c6da072f896"},
+			expectStr:  []string{`{"fnords":"smarf"}`},
+		},
+		{
+			name:       "nil",
+			input:      []any{nil, nil},
+			expectHash: []string{"", ""},
+			expectStr:  []string{"", ""},
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			hs := HideAll(test.input...)
+			for i, h := range hs {
+				expectHash := test.expectHash[i]
+				expectStr := test.expectStr[i]
+
+				if h.Conceal() != expectHash {
+					t.Errorf(`expected Conceal() result "%s", got "%s"`, expectHash, h.Conceal())
+				}
+				if h.String() != expectStr {
+					t.Errorf(`expected String() result "%s", got "%s"`, expectStr, h.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the various functions and structs
for handling secrets variables.  Secrets
are used to hash and mask PII from
clues' structured ctx and errors, as well
as upstream logging.

Todos: integrate secrets and Concealer
into the rest of clues structures.  Add
configuration for selecting hash algs
on init.