### PR TITLE
optimize error value storage

### DIFF
--- a/err.go
+++ b/err.go
@@ -122,7 +122,7 @@ func (err *Err) With(kvs ...any) *Err {
 
 	return &Err{
 		e:    err,
-		data: err.data.add(normalize(kvs...)),
+		data: values(normalize(kvs...)),
 	}
 }
 
@@ -155,7 +155,7 @@ func (err *Err) WithMap(m map[string]any) *Err {
 
 	return &Err{
 		e:    err,
-		data: err.data.add(m),
+		data: values(m),
 	}
 }
 


### PR DESCRIPTION
Since errs unwrap their entire tree to retrieve structured data, it isn't necessary to copy each map when adding new data.