### PR TITLE
protect against nil pointers from nil interface pointers

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"golang.org/x/exp/maps"
 )
@@ -110,6 +111,12 @@ func normalize(kvs ...any) map[string]any {
 
 func marshal(a any) string {
 	if a == nil {
+		return ""
+	}
+
+	// protect against nil pointer values with value-receiver funcs
+	rvo := reflect.ValueOf(a)
+	if rvo.Kind() == reflect.Ptr && rvo.IsNil() {
 		return ""
 	}
 

--- a/clues_test.go
+++ b/clues_test.go
@@ -382,3 +382,19 @@ func TestAdd_concealed(t *testing.T) {
 		})
 	}
 }
+
+type pointable struct{}
+
+func (p pointable) String() string {
+	return "pointable"
+}
+
+func TestPointerDereferenceMarshal(t *testing.T) {
+	var (
+		p   *pointable
+		ctx = context.Background()
+	)
+
+	// should not panic
+	clues.Add(ctx, "pointable", p)
+}

--- a/err.go
+++ b/err.go
@@ -220,6 +220,10 @@ func WithMap(err error, m map[string]any) *Err {
 // clues.Stack(err).WithClues(ctx) adds the same data as
 // clues.Stack(err).WithMap(clues.Values(ctx)).
 func (err *Err) WithClues(ctx context.Context) *Err {
+	if err == nil {
+		return nil
+	}
+
 	return err.WithMap(In(ctx))
 }
 
@@ -231,6 +235,10 @@ func (err *Err) WithClues(ctx context.Context) *Err {
 // clues.WithClues(err, ctx) adds the same data as
 // clues.WithMap(err, clues.Values(ctx)).
 func WithClues(err error, ctx context.Context) *Err {
+	if err == nil {
+		return nil
+	}
+
 	return WithMap(err, In(ctx))
 }
 
@@ -315,6 +323,10 @@ func format(err error, s fmt.State, verb rune) {
 // For all formatting besides %+v, the error printout should closely
 // mimic that of err.Error().
 func formatReg(err *Err, s fmt.State, verb rune) {
+	if err == nil {
+		return
+	}
+
 	write(s, verb, err.msg)
 
 	if len(err.msg) > 0 && err.e != nil {
@@ -335,6 +347,10 @@ func formatReg(err *Err, s fmt.State, verb rune) {
 // in %+v formatting, we output errors FIFO (ie, read from the
 // bottom of the stack first).
 func formatPlusV(err *Err, s fmt.State, verb rune) {
+	if err == nil {
+		return
+	}
+
 	for i := len(err.stack) - 1; i >= 0; i-- {
 		e := err.stack[i]
 		format(e, s, verb)
@@ -517,14 +533,21 @@ func Wrap(err error, msg string) *Err {
 //
 // Ex: Stack(sentinel, errors.New("base")).Error() => "sentinel: base"
 func Stack(errs ...error) *Err {
-	switch len(errs) {
+	filtered := []error{}
+	for _, err := range errs {
+		if err != nil {
+			filtered = append(filtered, err)
+		}
+	}
+
+	switch len(filtered) {
 	case 0:
 		return nil
 	case 1:
-		return toErr(errs[0], "")
+		return toErr(filtered[0], "")
 	}
 
-	return toStack(errs[0], errs[1:])
+	return toStack(filtered[0], filtered[1:])
 }
 
 // ---------------------------------------------------------------------------

--- a/err_test.go
+++ b/err_test.go
@@ -849,3 +849,21 @@ func TestToCore(t *testing.T) {
 		})
 	}
 }
+
+func TestStackNils(t *testing.T) {
+	result := clues.Stack(nil)
+	if result != nil {
+		t.Errorf("expected nil, got [%v]", result)
+	}
+
+	e := clues.New("err")
+	result = clues.Stack(e, nil)
+	if result.Error() != e.Error() {
+		t.Errorf("expected [%v], got [%v]", e, result)
+	}
+
+	result = clues.Stack(nil, e)
+	if result.Error() != e.Error() {
+		t.Errorf("expected [%v], got [%v]", e, result)
+	}
+}


### PR DESCRIPTION
Clues currently hits a nil-pointer exception when it attempts
to marshal a nil pointer for a struct that has a value-receiver
method for the Stringer interface.

This change also filters nil errors out of Stack inputs.