### PR TITLE
add secret format interface compliance

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -80,7 +80,7 @@ type Concealer interface {
 	Conceal() string
 	// Concealers also need to comply with Format
 	// It's a bit overbearing, but complying with Concealer
-	// doesn't guarantee any caller that thee variable won't
+	// doesn't provide guarantees that the variable won't
 	// pass into fmt.Printf("%v") and skip the whole hash.
 	// This is for your protection, too.
 	Format(fs fmt.State, verb rune)

--- a/secrets.go
+++ b/secrets.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -64,9 +65,32 @@ func makeDefaultHash() HashCfg {
 // types and interfaces
 // ---------------------------------------------------------------------------
 
+type PlainConcealer interface {
+	PlainStringer
+	Concealer
+}
+
+// PlainStringer is the opposite of conceal.
+// Useful for if you want to retrieve the raw value of a secret.
+type PlainStringer interface {
+	PlainString() string
+}
+
 type Concealer interface {
 	Conceal() string
+	// Concealers also need to comply with Format
+	// It's a bit overbearing, but complying with Concealer
+	// doesn't guarantee any caller that thee variable won't
+	// pass into fmt.Printf("%v") and skip the whole hash.
+	// This is for your protection, too.
+	Format(fs fmt.State, verb rune)
 }
+
+// compliance guarantees
+var (
+	_ Concealer     = &secret{}
+	_ PlainStringer = &secret{}
+)
 
 type secret struct {
 	s string
@@ -74,8 +98,12 @@ type secret struct {
 	h string
 }
 
-func (s secret) String() string  { return s.s }
-func (s secret) Conceal() string { return s.h }
+// use the hashed string in any fmt verb.
+func (s secret) Format(fs fmt.State, verb rune) { io.WriteString(fs, s.h) }
+func (s secret) String() string                 { return s.h }
+func (s secret) Conceal() string                { return s.h }
+func (s secret) PlainString() string            { return s.s }
+func (s secret) V() any                         { return s.v }
 
 // ---------------------------------------------------------------------------
 // concealer constructors

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,6 +1,9 @@
 package clues
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // set the hash alg key for consistency
 func init() {
@@ -49,39 +52,60 @@ func TestConceal(t *testing.T) {
 
 func TestMask(t *testing.T) {
 	table := []struct {
-		name   string
-		input  any
-		expect string
+		name        string
+		input       any
+		expectPlain string
 	}{
 		{
-			name:   "string",
-			input:  "fnords",
-			expect: "fnords",
+			name:        "string",
+			input:       "fnords",
+			expectPlain: "fnords",
 		},
 		{
-			name:   "stringer",
-			input:  mockStringer{"fnords"},
-			expect: "{s:fnords}",
+			name:        "stringer",
+			input:       mockStringer{"fnords"},
+			expectPlain: "{s:fnords}",
 		},
 		{
-			name:   "map",
-			input:  map[string]string{"fnords": "smarf"},
-			expect: `{"fnords":"smarf"}`,
+			name:        "map",
+			input:       map[string]string{"fnords": "smarf"},
+			expectPlain: `{"fnords":"smarf"}`,
 		},
 		{
-			name:   "nil",
-			input:  nil,
-			expect: ``,
+			name:        "nil",
+			input:       nil,
+			expectPlain: ``,
 		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
+			expect := "***"
+
 			m := Mask(test.input)
-			if m.Conceal() != "***" {
-				t.Errorf(`expected Conceal() result "***", got "%s"`, m.Conceal())
+			if m.Conceal() != expect {
+				t.Errorf(`expected Conceal() result "%s", got "%s"`, expect, m.Conceal())
 			}
-			if m.String() != test.expect {
-				t.Errorf(`expected String() result "%s", got "%s"`, test.expect, m.String())
+			if m.String() != expect {
+				t.Errorf(`expected String() result "%s", got "%s"`, expect, m.String())
+			}
+			if m.PlainString() != test.expectPlain {
+				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, m.PlainString())
+			}
+			result := fmt.Sprintf("%s", m)
+			if result != expect {
+				t.Errorf(`expected %%s fmt result "%s", got "%s`, expect, result)
+			}
+			result = fmt.Sprintf("%v", m)
+			if result != expect {
+				t.Errorf(`expected %%v fmt result "%s", got "%s`, expect, result)
+			}
+			result = fmt.Sprintf("%+v", m)
+			if result != expect {
+				t.Errorf(`expected %%+v fmt result "%s", got "%s`, expect, result)
+			}
+			result = fmt.Sprintf("%#v", m)
+			if result != expect {
+				t.Errorf(`expected %%#v fmt result "%s", got "%s`, expect, result)
 			}
 		})
 	}
@@ -89,40 +113,40 @@ func TestMask(t *testing.T) {
 
 func TestHide(t *testing.T) {
 	table := []struct {
-		name       string
-		input      any
-		expectHash string
-		expectStr  string
+		name        string
+		input       any
+		expectHash  string
+		expectPlain string
 	}{
 		{
-			name:       "string",
-			input:      "fnords",
-			expectHash: "7745164c2e6b3c97",
-			expectStr:  "fnords",
+			name:        "string",
+			input:       "fnords",
+			expectHash:  "7745164c2e6b3c97",
+			expectPlain: "fnords",
 		},
 		{
-			name:       "int",
-			input:      1,
-			expectHash: "1e29272d274ab30f",
-			expectStr:  "1",
+			name:        "int",
+			input:       1,
+			expectHash:  "1e29272d274ab30f",
+			expectPlain: "1",
 		},
 		{
-			name:       "stringer",
-			input:      mockStringer{"fnords"},
-			expectHash: "553c83b5702ada92",
-			expectStr:  "{s:fnords}",
+			name:        "stringer",
+			input:       mockStringer{"fnords"},
+			expectHash:  "553c83b5702ada92",
+			expectPlain: "{s:fnords}",
 		},
 		{
-			name:       "map",
-			input:      map[string]string{"fnords": "smarf"},
-			expectHash: "1502957923bb4cc8",
-			expectStr:  `{"fnords":"smarf"}`,
+			name:        "map",
+			input:       map[string]string{"fnords": "smarf"},
+			expectHash:  "1502957923bb4cc8",
+			expectPlain: `{"fnords":"smarf"}`,
 		},
 		{
-			name:       "nil",
-			input:      nil,
-			expectHash: "",
-			expectStr:  ``,
+			name:        "nil",
+			input:       nil,
+			expectHash:  "",
+			expectPlain: ``,
 		},
 	}
 	for _, test := range table {
@@ -131,8 +155,27 @@ func TestHide(t *testing.T) {
 			if h.Conceal() != test.expectHash {
 				t.Errorf(`expected Conceal() result "%s", got "%s"`, test.expectHash, h.Conceal())
 			}
-			if h.String() != test.expectStr {
-				t.Errorf(`expected String() result "%s", got "%s"`, test.expectStr, h.String())
+			if h.String() != test.expectHash {
+				t.Errorf(`expected String() result "%s", got "%s"`, test.expectHash, h.String())
+			}
+			if h.PlainString() != test.expectPlain {
+				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, h.PlainString())
+			}
+			result := fmt.Sprintf("%s", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%s fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%v fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%+v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%+v fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%#v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%#v fmt result "%s", got "%s`, test.expectHash, result)
 			}
 		})
 	}
@@ -140,34 +183,34 @@ func TestHide(t *testing.T) {
 
 func TestHideAll(t *testing.T) {
 	table := []struct {
-		name       string
-		input      []any
-		expectHash []string
-		expectStr  []string
+		name        string
+		input       []any
+		expectHash  []string
+		expectPlain []string
 	}{
 		{
-			name:       "string, int",
-			input:      []any{"fnords", 1},
-			expectHash: []string{"7745164c2e6b3c97", "1e29272d274ab30f"},
-			expectStr:  []string{"fnords", "1"},
+			name:        "string, int",
+			input:       []any{"fnords", 1},
+			expectHash:  []string{"7745164c2e6b3c97", "1e29272d274ab30f"},
+			expectPlain: []string{"fnords", "1"},
 		},
 		{
-			name:       "stringer",
-			input:      []any{mockStringer{"fnords"}, mockStringer{"smarf"}},
-			expectHash: []string{"553c83b5702ada92", "71e19af12aa87603"},
-			expectStr:  []string{"{s:fnords}", "{s:smarf}"},
+			name:        "stringer",
+			input:       []any{mockStringer{"fnords"}, mockStringer{"smarf"}},
+			expectHash:  []string{"553c83b5702ada92", "71e19af12aa87603"},
+			expectPlain: []string{"{s:fnords}", "{s:smarf}"},
 		},
 		{
-			name:       "map",
-			input:      []any{map[string]string{"fnords": "smarf"}},
-			expectHash: []string{"1502957923bb4cc8"},
-			expectStr:  []string{`{"fnords":"smarf"}`},
+			name:        "map",
+			input:       []any{map[string]string{"fnords": "smarf"}},
+			expectHash:  []string{"1502957923bb4cc8"},
+			expectPlain: []string{`{"fnords":"smarf"}`},
 		},
 		{
-			name:       "nil",
-			input:      []any{nil, nil},
-			expectHash: []string{"", ""},
-			expectStr:  []string{"", ""},
+			name:        "nil",
+			input:       []any{nil, nil},
+			expectHash:  []string{"", ""},
+			expectPlain: []string{"", ""},
 		},
 	}
 	for _, test := range table {
@@ -175,13 +218,15 @@ func TestHideAll(t *testing.T) {
 			hs := HideAll(test.input...)
 			for i, h := range hs {
 				expectHash := test.expectHash[i]
-				expectStr := test.expectStr[i]
 
 				if h.Conceal() != expectHash {
 					t.Errorf(`expected Conceal() result "%s", got "%s"`, expectHash, h.Conceal())
 				}
-				if h.String() != expectStr {
-					t.Errorf(`expected String() result "%s", got "%s"`, expectStr, h.String())
+				if h.String() != expectHash {
+					t.Errorf(`expected String() result "%s", got "%s"`, expectHash, h.String())
+				}
+				if h.PlainString() != test.expectPlain[i] {
+					t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain[i], h.String())
 				}
 			}
 		})


### PR DESCRIPTION
Adds the Format() method to secret, so that all
secret structs print out their hashed value when
passed through a formatter template, regardless
of the verb.

Also corrects the secret stringer compliance
by returning the hashed value instead of the
plaintext value.  This would have opened up
a gotcha otherwise, allowing users to print the
plaintext secret when they might expect the
output to contain the hashed value instead.