### PR TITLE
Improve memory management, add benchmark tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ func foo(ctx context.Context, someID string) error {
 }
 ```
 
-Keep error messages readable, and augment your telemetry, by packing errors with structured data.
+Keep error messages readable and augment your telemetry by packing errors with structured data.
 ```go
 func bar(ctx context.Context, someID string) error {
     err := doThing(ctx, someID)
@@ -34,6 +34,20 @@ func main() {
             Error("calling foo").
             WithError(err).
             WithAll(clues.InErr(err))
+    }
+}
+```
+
+## Thread-safe handling
+```go
+func iterateOver(ctx context.Context, ids []string) {
+    ctx = clues.Add(ctx, "status", good)
+    for _, id := range ids {
+        ictx := clues.Add(ctx, "currentID", id)
+        err := doSomething(ictx, id)
+        if err != nil {
+            ictx = clues.Add(ictx, "status", bad)
+        }
     }
 }
 ```

--- a/clues.go
+++ b/clues.go
@@ -29,10 +29,6 @@ type dataNode struct {
 	vs     map[string]any
 }
 
-func newNode(m map[string]any) *dataNode {
-	return &dataNode{vs: m}
-}
-
 func (dn *dataNode) add(m map[string]any) *dataNode {
 	return &dataNode{
 		parent: dn,

--- a/clues_benchmark_test.go
+++ b/clues_benchmark_test.go
@@ -1,0 +1,243 @@
+package clues_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/alcionai/clues"
+)
+
+var (
+	benchKeys []int64
+	benchVals []int64
+)
+
+const benchSize = 4096
+
+func init() {
+	benchKeys, benchVals = make([]int64, benchSize), make([]int64, benchSize)
+	for i := 0; i < benchSize; i++ {
+		benchKeys[i], benchVals[i] = rand.Int63(), rand.Int63()
+	}
+	rand.Shuffle(benchSize, func(i, j int) {
+		benchKeys[i], benchKeys[j] = benchKeys[j], benchKeys[i]
+	})
+}
+
+func BenchmarkAdd_singleConstKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", "bar")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleStaticKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchSize-i, i)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleConstKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", i)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleStaticKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, i, "bar")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleConstKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", benchVals[i%benchSize])
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleRandKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], "bar")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_singleRandKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multConstKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", "bar", "baz", "qux")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multStaticKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchSize-i, i, i-benchSize, i)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multConstKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", i, "baz", -i)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multStaticKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, i, "bar", -i, "qux")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multConstKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(
+			ctx,
+			"foo", benchVals[i%benchSize],
+			"baz", -benchVals[i%benchSize])
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multRandKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(
+			ctx,
+			benchVals[i%benchSize], "bar",
+			-benchVals[i%benchSize], "qux")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAdd_multRandKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(
+			ctx,
+			benchVals[i%benchSize], benchVals[i%benchSize],
+			-benchVals[i%benchSize], -benchVals[i%benchSize])
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_constKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[string]string{"foo": "bar", "baz": "qux"}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_staticKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[int]int{benchSize - i: i, i - benchSize: i}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_constKStaticV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[string]int{"foo": i, "baz": -i}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_staticKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[int]string{i: "bar", -i: "qux"}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_constKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[string]int64{
+			"foo": benchVals[i%benchSize],
+			"baz": -benchVals[i%benchSize],
+		}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_randKConstV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[int64]string{
+			benchVals[i%benchSize]:  "bar",
+			-benchVals[i%benchSize]: "qux",
+		}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkAddMap_randKRandV(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		m := map[int64]int64{
+			benchVals[i%benchSize]:  benchVals[i%benchSize],
+			-benchVals[i%benchSize]: -benchVals[i%benchSize],
+		}
+		ctx = clues.AddMap(ctx, m)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkIn_const(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", "bar")
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkIn_static(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchSize-i, i)
+		clues.In(ctx)
+	}
+}
+
+func BenchmarkIn_rand(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
+		clues.In(ctx)
+	}
+}

--- a/clues_benchmark_test.go
+++ b/clues_benchmark_test.go
@@ -29,7 +29,6 @@ func BenchmarkAdd_singleConstKConstV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", "bar")
-		clues.In(ctx)
 	}
 }
 
@@ -37,7 +36,6 @@ func BenchmarkAdd_singleStaticKStaticV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchSize-i, i)
-		clues.In(ctx)
 	}
 }
 
@@ -45,7 +43,6 @@ func BenchmarkAdd_singleConstKStaticV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", i)
-		clues.In(ctx)
 	}
 }
 
@@ -53,7 +50,6 @@ func BenchmarkAdd_singleStaticKConstV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, i, "bar")
-		clues.In(ctx)
 	}
 }
 
@@ -61,7 +57,6 @@ func BenchmarkAdd_singleConstKRandV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", benchVals[i%benchSize])
-		clues.In(ctx)
 	}
 }
 
@@ -69,7 +64,6 @@ func BenchmarkAdd_singleRandKConstV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchVals[i%benchSize], "bar")
-		clues.In(ctx)
 	}
 }
 
@@ -77,7 +71,6 @@ func BenchmarkAdd_singleRandKRandV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
-		clues.In(ctx)
 	}
 }
 
@@ -85,7 +78,6 @@ func BenchmarkAdd_multConstKConstV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", "bar", "baz", "qux")
-		clues.In(ctx)
 	}
 }
 
@@ -93,7 +85,6 @@ func BenchmarkAdd_multStaticKStaticV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchSize-i, i, i-benchSize, i)
-		clues.In(ctx)
 	}
 }
 
@@ -101,7 +92,6 @@ func BenchmarkAdd_multConstKStaticV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", i, "baz", -i)
-		clues.In(ctx)
 	}
 }
 
@@ -109,7 +99,6 @@ func BenchmarkAdd_multStaticKConstV(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, i, "bar", -i, "qux")
-		clues.In(ctx)
 	}
 }
 
@@ -120,7 +109,6 @@ func BenchmarkAdd_multConstKRandV(b *testing.B) {
 			ctx,
 			"foo", benchVals[i%benchSize],
 			"baz", -benchVals[i%benchSize])
-		clues.In(ctx)
 	}
 }
 
@@ -131,7 +119,6 @@ func BenchmarkAdd_multRandKConstV(b *testing.B) {
 			ctx,
 			benchVals[i%benchSize], "bar",
 			-benchVals[i%benchSize], "qux")
-		clues.In(ctx)
 	}
 }
 
@@ -142,7 +129,6 @@ func BenchmarkAdd_multRandKRandV(b *testing.B) {
 			ctx,
 			benchVals[i%benchSize], benchVals[i%benchSize],
 			-benchVals[i%benchSize], -benchVals[i%benchSize])
-		clues.In(ctx)
 	}
 }
 
@@ -151,7 +137,6 @@ func BenchmarkAddMap_constKConstV(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m := map[string]string{"foo": "bar", "baz": "qux"}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -160,7 +145,6 @@ func BenchmarkAddMap_staticKStaticV(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m := map[int]int{benchSize - i: i, i - benchSize: i}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -169,7 +153,6 @@ func BenchmarkAddMap_constKStaticV(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m := map[string]int{"foo": i, "baz": -i}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -178,7 +161,6 @@ func BenchmarkAddMap_staticKConstV(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		m := map[int]string{i: "bar", -i: "qux"}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -190,7 +172,6 @@ func BenchmarkAddMap_constKRandV(b *testing.B) {
 			"baz": -benchVals[i%benchSize],
 		}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -202,7 +183,6 @@ func BenchmarkAddMap_randKConstV(b *testing.B) {
 			-benchVals[i%benchSize]: "qux",
 		}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
@@ -214,30 +194,35 @@ func BenchmarkAddMap_randKRandV(b *testing.B) {
 			-benchVals[i%benchSize]: -benchVals[i%benchSize],
 		}
 		ctx = clues.AddMap(ctx, m)
-		clues.In(ctx)
 	}
 }
 
 func BenchmarkIn_const(b *testing.B) {
 	ctx := context.Background()
+	dn := clues.In(ctx)
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", "bar")
-		clues.In(ctx)
+		dn = clues.In(ctx)
 	}
+	_ = dn
 }
 
 func BenchmarkIn_static(b *testing.B) {
 	ctx := context.Background()
+	dn := clues.In(ctx)
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchSize-i, i)
-		clues.In(ctx)
+		dn = clues.In(ctx)
 	}
+	_ = dn
 }
 
 func BenchmarkIn_rand(b *testing.B) {
 	ctx := context.Background()
+	dn := clues.In(ctx)
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
-		clues.In(ctx)
+		dn = clues.In(ctx)
 	}
+	_ = dn
 }

--- a/err.go
+++ b/err.go
@@ -38,7 +38,7 @@ type Err struct {
 
 	// data is the record of contextual data produced,
 	// presumably, at the time the error is created or wrapped.
-	data *valueNode
+	data *dataNode
 }
 
 func toErr(e error, msg string, m map[string]any) *Err {
@@ -48,7 +48,7 @@ func toErr(e error, msg string, m map[string]any) *Err {
 		e:        e,
 		location: fmt.Sprintf("%s:%d", file, line),
 		msg:      msg,
-		data:     &valueNode{vs: m},
+		data:     &dataNode{vs: m},
 	}
 }
 

--- a/err.go
+++ b/err.go
@@ -38,16 +38,17 @@ type Err struct {
 
 	// data is the record of contextual data produced,
 	// presumably, at the time the error is created or wrapped.
-	data values
+	data *valueNode
 }
 
-func toErr(e error, msg string) *Err {
+func toErr(e error, msg string, m map[string]any) *Err {
 	_, file, line, _ := runtime.Caller(2)
 
 	return &Err{
 		e:        e,
 		location: fmt.Sprintf("%s:%d", file, line),
 		msg:      msg,
+		data:     &valueNode{vs: m},
 	}
 }
 
@@ -103,7 +104,7 @@ func Label(err error, label string) *Err {
 
 	e, ok := err.(*Err)
 	if !ok {
-		e = toErr(err, "")
+		e = toErr(err, "", nil)
 	}
 
 	return e.Label(label)
@@ -153,14 +154,11 @@ func (err *Err) With(kvs ...any) *Err {
 		return nil
 	}
 
-	if len(err.data) == 0 {
-		err.data = values{}
+	if len(kvs) > 0 {
+		err.data = err.data.add(normalize(kvs...))
 	}
 
-	return &Err{
-		e:    err,
-		data: values(normalize(kvs...)),
-	}
+	return err
 }
 
 // With adds every two values as a key,value pair to
@@ -174,7 +172,7 @@ func With(err error, kvs ...any) *Err {
 
 	e, ok := err.(*Err)
 	if !ok {
-		e = toErr(err, "")
+		return toErr(err, "", normalize(kvs...))
 	}
 
 	return e.With(kvs...)
@@ -186,14 +184,11 @@ func (err *Err) WithMap(m map[string]any) *Err {
 		return nil
 	}
 
-	if len(err.data) == 0 {
-		err.data = values{}
+	if len(m) > 0 {
+		err.data = err.data.add(m)
 	}
 
-	return &Err{
-		e:    err,
-		data: values(m),
-	}
+	return err
 }
 
 // WithMap copies the map to the Err's data map.
@@ -206,7 +201,7 @@ func WithMap(err error, m map[string]any) *Err {
 
 	e, ok := err.(*Err)
 	if !ok {
-		e = toErr(err, "")
+		return toErr(err, "", m)
 	}
 
 	return e.WithMap(m)
@@ -224,7 +219,7 @@ func (err *Err) WithClues(ctx context.Context) *Err {
 		return nil
 	}
 
-	return err.WithMap(In(ctx))
+	return err.WithMap(In(ctx).Map())
 }
 
 // WithClues is syntactical-sugar that assumes you're using
@@ -239,26 +234,26 @@ func WithClues(err error, ctx context.Context) *Err {
 		return nil
 	}
 
-	return WithMap(err, In(ctx))
+	return WithMap(err, In(ctx).Map())
 }
 
 // Values returns a copy of all of the contextual data in
 // the error.  Each error in the stack is unwrapped and all
 // maps are unioned. In case of collision, lower level error
 // data take least priority.
-func (err *Err) Values() values {
+func (err *Err) Values() map[string]any {
 	if err == nil {
-		return values{}
+		return map[string]any{}
 	}
 
-	vals := values{}
+	vals := map[string]any{}
 
 	for _, se := range err.stack {
 		maps.Copy(vals, InErr(se))
 	}
 
 	maps.Copy(vals, InErr(err.e))
-	maps.Copy(vals, err.data)
+	maps.Copy(vals, err.data.Map())
 
 	return vals
 }
@@ -267,9 +262,9 @@ func (err *Err) Values() values {
 // Each error in the stack is unwrapped and all maps are
 // unioned. In case of collision, lower level error data
 // take least priority.
-func InErr(err error) values {
+func InErr(err error) map[string]any {
 	if err == nil {
-		return values{}
+		return map[string]any{}
 	}
 
 	if e, ok := err.(*Err); ok {
@@ -514,7 +509,7 @@ func Unwrap(err error) error {
 // ------------------------------------------------------------
 
 func New(msg string) *Err {
-	return toErr(nil, msg)
+	return toErr(nil, msg, nil)
 }
 
 // Wrap returns a  clues.Err with a new message wrapping the old error.
@@ -523,7 +518,7 @@ func Wrap(err error, msg string) *Err {
 		return nil
 	}
 
-	return toErr(err, msg)
+	return toErr(err, msg, nil)
 }
 
 // Stack returns the error as a clues.Err.  If additional errors are
@@ -544,7 +539,7 @@ func Stack(errs ...error) *Err {
 	case 0:
 		return nil
 	case 1:
-		return toErr(filtered[0], "")
+		return toErr(filtered[0], "", nil)
 	}
 
 	return toStack(filtered[0], filtered[1:])
@@ -585,7 +580,7 @@ func ToCore(err error) *ErrCore {
 
 	e, ok := err.(*Err)
 	if !ok {
-		e = toErr(err, "")
+		e = toErr(err, "", nil)
 	}
 
 	return e.Core()

--- a/err_benchmark_test.go
+++ b/err_benchmark_test.go
@@ -1,0 +1,327 @@
+package clues_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/alcionai/clues"
+)
+
+func BenchmarkWith_singleConstKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", "bar")
+	}
+}
+
+func BenchmarkWith_singleStaticKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchSize-i, i)
+	}
+}
+
+func BenchmarkWith_singleConstKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", i)
+	}
+}
+
+func BenchmarkWith_singleStaticKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(i, "bar")
+	}
+}
+
+func BenchmarkWith_singleConstKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWith_singleRandKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchVals[i%benchSize], "bar")
+	}
+}
+
+func BenchmarkWith_singleRandKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchVals[i%benchSize], benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWith_multConstKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", "bar", "baz", "qux")
+	}
+}
+
+func BenchmarkWith_multStaticKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchSize-i, i, i-benchSize, i)
+	}
+}
+
+func BenchmarkWith_multConstKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", i, "baz", -i)
+	}
+}
+
+func BenchmarkWith_multStaticKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(i, "bar", -i, "qux")
+	}
+}
+
+func BenchmarkWith_multConstKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(
+			"foo", benchVals[i%benchSize],
+			"baz", -benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWith_multRandKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(
+			benchVals[i%benchSize], "bar",
+			-benchVals[i%benchSize], "qux")
+	}
+}
+
+func BenchmarkWith_multRandKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(
+			benchVals[i%benchSize], benchVals[i%benchSize],
+			-benchVals[i%benchSize], -benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWith_chainConstKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", "bar").
+			With("baz", "qux")
+	}
+}
+
+func BenchmarkWith_chainStaticKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchSize-i, i).
+			With(i-benchSize, i)
+	}
+}
+
+func BenchmarkWith_chainConstKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", i).
+			With("baz", -i)
+	}
+}
+
+func BenchmarkWith_chainStaticKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(i, "bar").
+			With(-i, "qux")
+	}
+}
+
+func BenchmarkWith_chainConstKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", benchVals[i%benchSize]).
+			With("baz", -benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWith_chainRandKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchVals[i%benchSize], "bar").
+			With(-benchVals[i%benchSize], "qux")
+	}
+}
+
+func BenchmarkWith_chainRandKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchVals[i%benchSize], benchVals[i%benchSize]).
+			With(-benchVals[i%benchSize], -benchVals[i%benchSize])
+	}
+}
+
+func BenchmarkWithMap_constKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{"foo": "bar", "baz": "qux"}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_staticKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{
+			strconv.Itoa(benchSize - i): i,
+			strconv.Itoa(i - benchSize): i,
+		}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_constKStaticV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{"foo": i, "baz": -i}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_staticKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{
+			strconv.Itoa(i):  "bar",
+			strconv.Itoa(-i): "qux",
+		}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_constKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{
+			"foo": benchVals[i%benchSize],
+			"baz": -benchVals[i%benchSize],
+		}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_randKConstV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{
+			strconv.FormatInt(benchVals[i%benchSize], 10):  "bar",
+			strconv.FormatInt(-benchVals[i%benchSize], 10): "qux",
+		}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithMap_randKRandV(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		m := map[string]any{
+			strconv.FormatInt(benchVals[i%benchSize], 10):  benchVals[i%benchSize],
+			strconv.FormatInt(-benchVals[i%benchSize], 10): -benchVals[i%benchSize],
+		}
+		err = err.WithMap(m)
+	}
+}
+
+func BenchmarkWithClues_constKConstV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", "bar")
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_staticKStaticV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchSize-i, i)
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_constKStaticV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", i)
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_staticKConstV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, i, "bar")
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_constKRandV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", benchVals[i%benchSize])
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_randKConstV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], "bar")
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkWithClues_randKRandV(b *testing.B) {
+	err := clues.New("err")
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
+		err = err.WithClues(ctx)
+	}
+}
+
+func BenchmarkInErr_const(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With("foo", "bar")
+		clues.InErr(err)
+	}
+}
+
+func BenchmarkInErr_static(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(i, -i)
+		clues.InErr(err)
+	}
+}
+
+func BenchmarkInErr_rand(b *testing.B) {
+	err := clues.New("err")
+	for i := 0; i < b.N; i++ {
+		err = err.With(benchVals[i%benchSize], benchVals[i%benchSize])
+		clues.InErr(err)
+	}
+}

--- a/err_benchmark_test.go
+++ b/err_benchmark_test.go
@@ -304,24 +304,30 @@ func BenchmarkWithClues_randKRandV(b *testing.B) {
 
 func BenchmarkInErr_const(b *testing.B) {
 	err := clues.New("err")
+	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With("foo", "bar")
-		clues.InErr(err)
+		m = clues.InErr(err)
 	}
+	_ = m
 }
 
 func BenchmarkInErr_static(b *testing.B) {
 	err := clues.New("err")
+	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With(i, -i)
-		clues.InErr(err)
+		m = clues.InErr(err)
 	}
+	_ = m
 }
 
 func BenchmarkInErr_rand(b *testing.B) {
 	err := clues.New("err")
+	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With(benchVals[i%benchSize], benchVals[i%benchSize])
-		clues.InErr(err)
+		m = clues.InErr(err)
 	}
+	_ = m
 }

--- a/err_test.go
+++ b/err_test.go
@@ -478,11 +478,6 @@ func TestImmutableErrors(t *testing.T) {
 		t.Errorf("previous map should not have been mutated by addition")
 	}
 
-	pre = clues.InErr(err)
-	if _, ok := pre["k2"]; ok {
-		t.Errorf("previous map within error should not have been mutated by addition")
-	}
-
 	post := clues.InErr(err2)
 	if post["k2"] != "v2" {
 		t.Errorf("new map should contain the added value")


### PR DESCRIPTION
## Goals

1. Add benchmark tests to evaluate library performance.
2. Refactor context memory management to enable thread-safe protection across branching additions without duplicating existing data at each addition.
3. Refactor error memory management to enable thread-safe protection across error context additions without duplicating error objects at each addition.

## Benchmarks

Some notable insights on the following benchmarks:
* The overall goal of this change is to ensure no single action gets out of hand.  Additional performance is nice, and can be improved still in the future, but maximizing performance across the board is not the current goal.
* The `StaticK*` benchmarks are technically the most accurate representations of real world usage, since they contain a minimum overlap across keys.  However these tests will, in all cases, stack data much deeper (thousands of nodes) than is realistically expected of a production environment (tens of nodes).
* While performance sees reasonable improvement in the general case, solving the `InErr()` timeouts is the biggest win.

### Before Changes
```
BenchmarkAdd_singleConstKConstV-10               1376434               789.9 ns/op           992 B/op          8 allocs/op
BenchmarkAdd_singleStaticKStaticV-10               10000            323316 ns/op          338917 B/op         22 allocs/op
BenchmarkAdd_singleConstKStaticV-10              1619610               743.1 ns/op          1016 B/op         10 allocs/op
BenchmarkAdd_singleStaticKConstV-10                10000            265893 ns/op          338878 B/op         19 allocs/op
BenchmarkAdd_singleConstKRandV-10                1489209               811.2 ns/op          1048 B/op         11 allocs/op
BenchmarkAdd_singleRandKConstV-10                  10000            168960 ns/op          238314 B/op         13 allocs/op
BenchmarkAdd_singleRandKRandV-10                   10000            192365 ns/op          238371 B/op         16 allocs/op
BenchmarkAdd_multConstKConstV-10                 1760774              1026 ns/op            1008 B/op          9 allocs/op
BenchmarkAdd_multStaticKStaticV-10                 10000            395954 ns/op          470004 B/op         29 allocs/op
BenchmarkAdd_multConstKStaticV-10                1000000              1442 ns/op            1056 B/op         14 allocs/op
BenchmarkAdd_multStaticKConstV-10                  10000            694954 ns/op          671398 B/op         37 allocs/op
BenchmarkAdd_multConstKRandV-10                   781983              1384 ns/op            1120 B/op         15 allocs/op
BenchmarkAdd_multRandKConstV-10                    10000            391174 ns/op          469039 B/op         20 allocs/op
BenchmarkAdd_multRandKRandV-10                     10000            433996 ns/op          469144 B/op         26 allocs/op
BenchmarkAddMap_constKConstV-10                  1186197              1565 ns/op            1136 B/op         14 allocs/op
BenchmarkAddMap_staticKStaticV-10                  10000            384590 ns/op          470112 B/op         32 allocs/op
BenchmarkAddMap_constKStaticV-10                  999336              1692 ns/op            1152 B/op         18 allocs/op
BenchmarkAddMap_staticKConstV-10                   10000            686717 ns/op          671478 B/op         40 allocs/op
BenchmarkAddMap_constKRandV-10                   1000000              1985 ns/op            1216 B/op         18 allocs/op
BenchmarkAddMap_randKConstV-10                     10000            371346 ns/op          469125 B/op         23 allocs/op
BenchmarkAddMap_randKRandV-10                      10000            393378 ns/op          469248 B/op         29 allocs/op
BenchmarkIn_const-10                             1564428               688.0 ns/op           992 B/op          8 allocs/op
BenchmarkIn_static-10                              10000            286547 ns/op          338913 B/op         22 allocs/op
BenchmarkIn_rand-10                                10000            188766 ns/op          238371 B/op         16 allocs/op
BenchmarkWith_singleConstKConstV-10              6823659               241.0 ns/op           448 B/op          4 allocs/op
BenchmarkWith_singleStaticKStaticV-10            3834045               336.9 ns/op           496 B/op          9 allocs/op
BenchmarkWith_singleConstKStaticV-10             4493137               262.1 ns/op           472 B/op          6 allocs/op
BenchmarkWith_singleStaticKConstV-10             4624930               261.4 ns/op           472 B/op          6 allocs/op
BenchmarkWith_singleConstKRandV-10               4286445               299.4 ns/op           503 B/op          7 allocs/op
BenchmarkWith_singleRandKConstV-10               4351930               289.1 ns/op           503 B/op          7 allocs/op
BenchmarkWith_singleRandKRandV-10                3232315               371.3 ns/op           559 B/op         10 allocs/op
BenchmarkWith_multConstKConstV-10                5094906               479.2 ns/op           464 B/op          5 allocs/op
BenchmarkWith_multStaticKStaticV-10              2126823               838.3 ns/op           560 B/op         16 allocs/op
BenchmarkWith_multConstKStaticV-10               2991151               482.1 ns/op           512 B/op         10 allocs/op
BenchmarkWith_multStaticKConstV-10               2782454               593.2 ns/op           512 B/op         10 allocs/op
BenchmarkWith_multConstKRandV-10                 2749723               694.1 ns/op           575 B/op         11 allocs/op
BenchmarkWith_multRandKConstV-10                 2379142               462.6 ns/op           575 B/op         11 allocs/op
BenchmarkWith_multRandKRandV-10                  1314402               874.5 ns/op           687 B/op         17 allocs/op
BenchmarkWith_chainConstKConstV-10               3051607               378.1 ns/op           896 B/op          8 allocs/op
BenchmarkWith_chainStaticKStaticV-10             1849600               692.0 ns/op           992 B/op         19 allocs/op
BenchmarkWith_chainConstKStaticV-10              2259436               535.7 ns/op           944 B/op         13 allocs/op
BenchmarkWith_chainStaticKConstV-10              2206014               525.2 ns/op           944 B/op         13 allocs/op
BenchmarkWith_chainConstKRandV-10                2176041               596.0 ns/op          1007 B/op         14 allocs/op
BenchmarkWith_chainRandKConstV-10                2150919               600.0 ns/op          1007 B/op         14 allocs/op
BenchmarkWith_chainRandKRandV-10                 1626723               759.9 ns/op          1119 B/op         20 allocs/op
BenchmarkWithMap_constKConstV-10                 7203932               173.6 ns/op           432 B/op          3 allocs/op
BenchmarkWithMap_staticKStaticV-10               5727504               216.7 ns/op           463 B/op          6 allocs/op
BenchmarkWithMap_constKStaticV-10                6696054               166.6 ns/op           448 B/op          4 allocs/op
BenchmarkWithMap_staticKConstV-10                5697630               194.0 ns/op           447 B/op          4 allocs/op
BenchmarkWithMap_constKRandV-10                  7057366               172.0 ns/op           448 B/op          5 allocs/op
BenchmarkWithMap_randKConstV-10                  5308044               213.1 ns/op           479 B/op          5 allocs/op
BenchmarkWithMap_randKRandV-10                   5014779               228.9 ns/op           495 B/op          7 allocs/op
BenchmarkWithClues_constKConstV-10               2031816               649.2 ns/op          1088 B/op          9 allocs/op
BenchmarkWithClues_staticKStaticV-10               10000            249326 ns/op          339016 B/op         23 allocs/op
BenchmarkWithClues_constKStaticV-10              1402378               928.2 ns/op          1112 B/op         11 allocs/op
BenchmarkWithClues_staticKConstV-10                10000            237654 ns/op          338967 B/op         20 allocs/op
BenchmarkWithClues_constKRandV-10                1493005               817.6 ns/op          1144 B/op         12 allocs/op
BenchmarkWithClues_randKConstV-10                  10000            190073 ns/op          238414 B/op         14 allocs/op
BenchmarkWithClues_randKRandV-10                   10000            161378 ns/op          238473 B/op         17 allocs/op
BenchmarkInErr_const-10                            10000           1432733 ns/op         1680719 B/op      10007 allocs/op
BenchmarkInErr_static-10                        fSIGQUIT: quit
*** Test killed with quit: ran too long (11m0s).
exit status 2
FAIL    github.com/alcionai/clues       660.059s
```

### After Changes
```
BenchmarkAdd_singleConstKConstV-10               1928366               824.2 ns/op           784 B/op          9 allocs/op
BenchmarkAdd_singleStaticKStaticV-10             1628745               787.6 ns/op           832 B/op         14 allocs/op
BenchmarkAdd_singleConstKStaticV-10              1658325               775.3 ns/op           808 B/op         11 allocs/op
BenchmarkAdd_singleStaticKConstV-10              1908662               553.3 ns/op           808 B/op         11 allocs/op
BenchmarkAdd_singleConstKRandV-10                1863534               568.9 ns/op           840 B/op         12 allocs/op
BenchmarkAdd_singleRandKConstV-10                1910954               563.9 ns/op           840 B/op         12 allocs/op
BenchmarkAdd_singleRandKRandV-10                 1752163               712.1 ns/op           896 B/op         15 allocs/op
BenchmarkAdd_multConstKConstV-10                 1989670               559.1 ns/op           800 B/op         10 allocs/op
BenchmarkAdd_multStaticKStaticV-10               1242932               993.5 ns/op           896 B/op         21 allocs/op
BenchmarkAdd_multConstKStaticV-10                1000000              1250 ns/op             848 B/op         16 allocs/op
BenchmarkAdd_multStaticKConstV-10                1616938              1089 ns/op             848 B/op         15 allocs/op
BenchmarkAdd_multConstKRandV-10                  1265910              1033 ns/op             912 B/op         16 allocs/op
BenchmarkAdd_multRandKConstV-10                  1000000              1027 ns/op             912 B/op         16 allocs/op
BenchmarkAdd_multRandKRandV-10                   1000000              1219 ns/op            1024 B/op         22 allocs/op
BenchmarkAddMap_constKConstV-10                  1326388               993.4 ns/op           928 B/op         15 allocs/op
BenchmarkAddMap_staticKStaticV-10                1000000              1126 ns/op            1008 B/op         24 allocs/op
BenchmarkAddMap_constKStaticV-10                 1000000              1036 ns/op             944 B/op         18 allocs/op
BenchmarkAddMap_staticKConstV-10                 1000000              1409 ns/op             944 B/op         18 allocs/op
BenchmarkAddMap_constKRandV-10                   1000000              1088 ns/op            1008 B/op         19 allocs/op
BenchmarkAddMap_randKConstV-10                   1000000              1168 ns/op            1008 B/op         19 allocs/op
BenchmarkAddMap_randKRandV-10                    1054890              1528 ns/op            1136 B/op         25 allocs/op
BenchmarkIn_const-10                             2275856               482.1 ns/op           784 B/op          9 allocs/op
BenchmarkIn_static-10                            1743090               628.2 ns/op           832 B/op         14 allocs/op
BenchmarkIn_rand-10                              1775120               694.1 ns/op           895 B/op         15 allocs/op
BenchmarkWith_singleConstKConstV-10              3284148               343.2 ns/op           704 B/op          6 allocs/op
BenchmarkWith_singleStaticKStaticV-10            2095527               531.9 ns/op           752 B/op         11 allocs/op
BenchmarkWith_singleConstKStaticV-10             2479923               454.5 ns/op           728 B/op          8 allocs/op
BenchmarkWith_singleStaticKConstV-10             2787708               463.9 ns/op           728 B/op          8 allocs/op
BenchmarkWith_singleConstKRandV-10               2391356               481.7 ns/op           760 B/op          9 allocs/op
BenchmarkWith_singleRandKConstV-10               2299364               476.4 ns/op           760 B/op          9 allocs/op
BenchmarkWith_singleRandKRandV-10                2098438               565.7 ns/op           815 B/op         12 allocs/op
BenchmarkWith_multConstKConstV-10                2728303               735.6 ns/op           720 B/op          7 allocs/op
BenchmarkWith_multStaticKStaticV-10              1412894              1072 ns/op             816 B/op         18 allocs/op
BenchmarkWith_multConstKStaticV-10               2025582               714.1 ns/op           768 B/op         12 allocs/op
BenchmarkWith_multStaticKConstV-10               1776141               629.9 ns/op           768 B/op         12 allocs/op
BenchmarkWith_multConstKRandV-10                 1747958              1011 ns/op             832 B/op         13 allocs/op
BenchmarkWith_multRandKConstV-10                 1722884               788.2 ns/op           832 B/op         13 allocs/op
BenchmarkWith_multRandKRandV-10                  1000000              1384 ns/op             944 B/op         19 allocs/op
BenchmarkWith_chainConstKConstV-10               1608531               709.4 ns/op          1408 B/op         12 allocs/op
BenchmarkWith_chainStaticKStaticV-10             1000000              1084 ns/op            1504 B/op         23 allocs/op
BenchmarkWith_chainConstKStaticV-10              1390452               940.4 ns/op          1456 B/op         17 allocs/op
BenchmarkWith_chainStaticKConstV-10              1229997              1263 ns/op            1456 B/op         17 allocs/op
BenchmarkWith_chainConstKRandV-10                1193283               966.7 ns/op          1520 B/op         18 allocs/op
BenchmarkWith_chainRandKConstV-10                1258813               950.1 ns/op          1520 B/op         18 allocs/op
BenchmarkWith_chainRandKRandV-10                 1000000              1235 ns/op            1632 B/op         24 allocs/op
BenchmarkWithMap_constKConstV-10                 5340348               251.8 ns/op           352 B/op          3 allocs/op
BenchmarkWithMap_staticKStaticV-10               4485530               296.7 ns/op           383 B/op          6 allocs/op
BenchmarkWithMap_constKStaticV-10                4862736               245.5 ns/op           367 B/op          4 allocs/op
BenchmarkWithMap_staticKConstV-10                4787144               270.4 ns/op           367 B/op          4 allocs/op
BenchmarkWithMap_constKRandV-10                  4957141               248.2 ns/op           368 B/op          5 allocs/op
BenchmarkWithMap_randKConstV-10                  4572518               287.1 ns/op           399 B/op          5 allocs/op
BenchmarkWithMap_randKRandV-10                   4263903               312.9 ns/op           415 B/op          7 allocs/op
BenchmarkWithClues_constKConstV-10                 10000            276624 ns/op            1472 B/op         14 allocs/op
BenchmarkWithClues_staticKStaticV-10               10000           1197163 ns/op         1052102 B/op        142 allocs/op
BenchmarkWithClues_constKStaticV-10                10000            277806 ns/op            1496 B/op         16 allocs/op
BenchmarkWithClues_staticKConstV-10                10000           1224210 ns/op         1051874 B/op        138 allocs/op
BenchmarkWithClues_constKRandV-10                  10000            276510 ns/op            1529 B/op         17 allocs/op
BenchmarkWithClues_randKConstV-10                  10000            919043 ns/op          739279 B/op         89 allocs/op
BenchmarkWithClues_randKRandV-10                   10000            852452 ns/op          739337 B/op         92 allocs/op
BenchmarkInErr_const-10                            10000            248625 ns/op            1424 B/op         11 allocs/op
BenchmarkInErr_static-10                           10000           1247076 ns/op         1428164 B/op        246 allocs/op
BenchmarkInErr_rand-10                             10000            957139 ns/op         1003028 B/op        158 allocs/op
PASS
ok      github.com/alcionai/clues       182.191s
```