### PR TITLE
return inErr resp to dataNode

### DIFF
--- a/clues_benchmark_test.go
+++ b/clues_benchmark_test.go
@@ -197,32 +197,80 @@ func BenchmarkAddMap_randKRandV(b *testing.B) {
 	}
 }
 
-func BenchmarkIn_const(b *testing.B) {
+func BenchmarkIn_constMap(b *testing.B) {
 	ctx := context.Background()
 	dn := clues.In(ctx)
+	m := map[string]any{}
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, "foo", "bar")
 		dn = clues.In(ctx)
+		m = dn.Map()
 	}
 	_ = dn
+	_ = m
 }
 
-func BenchmarkIn_static(b *testing.B) {
+func BenchmarkIn_staticMap(b *testing.B) {
 	ctx := context.Background()
 	dn := clues.In(ctx)
+	m := map[string]any{}
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchSize-i, i)
 		dn = clues.In(ctx)
+		m = dn.Map()
 	}
 	_ = dn
+	_ = m
 }
 
-func BenchmarkIn_rand(b *testing.B) {
+func BenchmarkIn_randMap(b *testing.B) {
 	ctx := context.Background()
 	dn := clues.In(ctx)
+	m := map[string]any{}
 	for i := 0; i < b.N; i++ {
 		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
 		dn = clues.In(ctx)
+		m = dn.Map()
 	}
 	_ = dn
+	_ = m
+}
+
+func BenchmarkIn_constSlice(b *testing.B) {
+	ctx := context.Background()
+	dn := clues.In(ctx)
+	s := []any{}
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, "foo", "bar")
+		dn = clues.In(ctx)
+		s = dn.Slice()
+	}
+	_ = dn
+	_ = s
+}
+
+func BenchmarkIn_staticSlice(b *testing.B) {
+	ctx := context.Background()
+	dn := clues.In(ctx)
+	s := []any{}
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchSize-i, i)
+		dn = clues.In(ctx)
+		s = dn.Slice()
+	}
+	_ = dn
+	_ = s
+}
+
+func BenchmarkIn_randSlice(b *testing.B) {
+	ctx := context.Background()
+	dn := clues.In(ctx)
+	s := []any{}
+	for i := 0; i < b.N; i++ {
+		ctx = clues.Add(ctx, benchVals[i%benchSize], benchVals[i%benchSize])
+		dn = clues.In(ctx)
+		s = dn.Slice()
+	}
+	_ = dn
+	_ = s
 }

--- a/err_benchmark_test.go
+++ b/err_benchmark_test.go
@@ -307,7 +307,7 @@ func BenchmarkInErr_const(b *testing.B) {
 	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With("foo", "bar")
-		m = clues.InErr(err)
+		m = clues.InErr(err).Map()
 	}
 	_ = m
 }
@@ -317,7 +317,7 @@ func BenchmarkInErr_static(b *testing.B) {
 	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With(i, -i)
-		m = clues.InErr(err)
+		m = clues.InErr(err).Map()
 	}
 	_ = m
 }
@@ -327,7 +327,7 @@ func BenchmarkInErr_rand(b *testing.B) {
 	var m map[string]any
 	for i := 0; i < b.N; i++ {
 		err = err.With(benchVals[i%benchSize], benchVals[i%benchSize])
-		m = clues.InErr(err)
+		m = clues.InErr(err).Map()
 	}
 	_ = m
 }

--- a/err_test.go
+++ b/err_test.go
@@ -146,8 +146,8 @@ func TestWith(t *testing.T) {
 			for _, kv := range test.with {
 				err = err.With(kv...)
 			}
-			mustEquals(t, test.expect, clues.InErr(err))
-			mustEquals(t, test.expect, err.Values())
+			mustEquals(t, test.expect, clues.InErr(err).Map())
+			mustEquals(t, test.expect, err.Values().Map())
 		})
 	}
 }
@@ -181,8 +181,8 @@ func TestWithMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := clues.WithMap(test.initial, test.kv)
 			err = err.WithMap(test.with)
-			mustEquals(t, test.expect, clues.InErr(err))
-			mustEquals(t, test.expect, err.Values())
+			mustEquals(t, test.expect, clues.InErr(err).Map())
+			mustEquals(t, test.expect, err.Values().Map())
 		})
 	}
 }
@@ -219,8 +219,8 @@ func TestWithClues(t *testing.T) {
 			tctx := clues.AddMap(ctx, test.kv)
 			err := clues.WithClues(test.initial, tctx)
 			err = err.WithMap(test.with)
-			mustEquals(t, test.expect, clues.InErr(err))
-			mustEquals(t, test.expect, err.Values())
+			mustEquals(t, test.expect, clues.InErr(err).Map())
+			mustEquals(t, test.expect, err.Values().Map())
 		})
 	}
 }
@@ -462,7 +462,7 @@ func TestErrValues_stacks(t *testing.T) {
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
 			vs := clues.InErr(test.err)
-			mustEquals(t, test.expect, vs)
+			mustEquals(t, test.expect, vs.Map())
 		})
 	}
 }
@@ -471,15 +471,15 @@ func TestImmutableErrors(t *testing.T) {
 	err := clues.New("an error").With("k", "v")
 	check := msa{"k": "v"}
 	pre := clues.InErr(err)
-	mustEquals(t, check, pre)
+	mustEquals(t, check, pre.Map())
 
 	err2 := err.With("k2", "v2")
-	if _, ok := pre["k2"]; ok {
+	if _, ok := pre.Map()["k2"]; ok {
 		t.Errorf("previous map should not have been mutated by addition")
 	}
 
 	post := clues.InErr(err2)
-	if post["k2"] != "v2" {
+	if post.Map()["k2"] != "v2" {
 		t.Errorf("new map should contain the added value")
 	}
 }


### PR DESCRIPTION
returns the inErr resp to a dataNode type,
after changing it to a plain map in the previous
PR, which removed the Slice and Map methods.