### PR TITLE
add WithTrace and OrNil

### DIFF
--- a/err.go
+++ b/err.go
@@ -42,24 +42,25 @@ type Err struct {
 }
 
 func toErr(e error, msg string, m map[string]any) *Err {
-	_, file, line, _ := runtime.Caller(2)
-
 	return &Err{
 		e:        e,
-		location: fmt.Sprintf("%s:%d", file, line),
+		location: getTrace(3),
 		msg:      msg,
 		data:     &dataNode{vs: m},
 	}
 }
 
 func toStack(e error, stack []error) *Err {
-	_, file, line, _ := runtime.Caller(2)
-
 	return &Err{
 		e:        e,
-		location: fmt.Sprintf("%s:%d", file, line),
+		location: getTrace(3),
 		stack:    stack,
 	}
+}
+
+func getTrace(depth int) string {
+	_, file, line, _ := runtime.Caller(depth)
+	return fmt.Sprintf("%s:%d", file, line)
 }
 
 // ------------------------------------------------------------
@@ -184,6 +185,53 @@ func With(err error, kvs ...any) *Err {
 	return e.With(kvs...)
 }
 
+// WithTrace sets the error trace to a certain depth.
+// Error traces are already generated for the location
+// where clues.Wrap or clues.Stack was called.  This
+// call is for cases where Wrap or Stack calls are handled
+// in a helper func and are not reporting the actual
+// error origin.
+func (err *Err) WithTrace(depth int) *Err {
+	if err == nil {
+		return nil
+	}
+
+	if depth < 0 {
+		depth = 0
+	}
+
+	err.location = getTrace(depth + 2)
+
+	return err
+}
+
+// WithTrace sets the error trace to a certain depth.
+// Error traces are already generated for the location
+// where clues.Wrap or clues.Stack was called.  This
+// call is for cases where Wrap or Stack calls are handled
+// in a helper func and are not reporting the actual
+// error origin.
+// If err is not an *Err intance, returns the error wrapped
+// into an *Err struct.
+func WithTrace(err error, depth int) *Err {
+	if err == nil {
+		return nil
+	}
+
+	e, ok := err.(*Err)
+	if !ok {
+		return toErr(err, "", map[string]any{})
+	}
+
+	// needed both here and in withTrace() to
+	// correct for the extra call depth.
+	if depth < 0 {
+		depth = 0
+	}
+
+	return e.WithTrace(depth + 1)
+}
+
 // WithMap copies the map to the Err's data map.
 func (err *Err) WithMap(m map[string]any) *Err {
 	if err == nil {
@@ -241,6 +289,18 @@ func WithClues(err error, ctx context.Context) *Err {
 	}
 
 	return WithMap(err, In(ctx).Map())
+}
+
+// OrNil is a workaround for golang's infamous "an interface
+// holding a nil value is not nil" gotcha.  You can use it at
+// the end of error formatting chains to ensure a correct nil
+// return value.
+func (err *Err) OrNil() error {
+	if err == nil {
+		return nil
+	}
+
+	return err
 }
 
 // Values returns a copy of all of the contextual data in

--- a/err.go
+++ b/err.go
@@ -186,6 +186,8 @@ func With(err error, kvs ...any) *Err {
 }
 
 // WithTrace sets the error trace to a certain depth.
+// A depth of 0 traces to the func where WithTrace is
+// called.  1 sets the trace to its parent, etc.
 // Error traces are already generated for the location
 // where clues.Wrap or clues.Stack was called.  This
 // call is for cases where Wrap or Stack calls are handled
@@ -206,6 +208,8 @@ func (err *Err) WithTrace(depth int) *Err {
 }
 
 // WithTrace sets the error trace to a certain depth.
+// A depth of 0 traces to the func where WithTrace is
+// called.  1 sets the trace to its parent, etc.
 // Error traces are already generated for the location
 // where clues.Wrap or clues.Stack was called.  This
 // call is for cases where Wrap or Stack calls are handled

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1292,6 +1292,117 @@ func TestFmt_nestedFuncs(t *testing.T) {
 	}
 }
 
+func TestWithTrace(t *testing.T) {
+	table := []struct {
+		name   string
+		tracer func(err error) error
+		expect string
+	}{
+		{
+			name: "error -1",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, -1)
+			},
+			expect: plusRE(`an error\n`, `err_test.go:\d+$`),
+		},
+		{
+			name: "error 0",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, 0)
+			},
+			expect: plusRE(`an error\n`, `err_test.go:\d+$`),
+		},
+		{
+			name: "error 1",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, 1)
+			},
+			expect: plusRE(`an error\n`, `err_fmt_test.go:\d+$`),
+		},
+		{
+			name: "error 2",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, 2)
+			},
+			expect: plusRE(`an error\n`, `err_fmt_test.go:\d+$`),
+		},
+		{
+			name: "error 3",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, 3)
+			},
+			expect: plusRE(`an error\n`, `testing/testing.go:\d+$`),
+		},
+		{
+			name: "error 4",
+			tracer: func(err error) error {
+				return withTraceWrapper(err, 4)
+			},
+			expect: plusRE(`an error\n`, `runtime/.*:\d+$`),
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			checkFmt{"%+v", "", regexp.MustCompile(test.expect)}.
+				check(t, test.tracer(cluErr))
+		})
+	}
+	table2 := []struct {
+		name   string
+		tracer func(err *clues.Err) error
+		expect string
+	}{
+		{
+			name: "clues.Err -1",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, -1)
+			},
+			expect: plusRE(`an error\n`, `err_test.go:\d+$`),
+		},
+		{
+			name: "clues.Err 0",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, 0)
+			},
+			expect: plusRE(`an error\n`, `err_test.go:\d+$`),
+		},
+		{
+			name: "clues.Err 1",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, 1)
+			},
+			expect: plusRE(`an error\n`, `err_fmt_test.go:\d+$`),
+		},
+		{
+			name: "clues.Err 2",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, 2)
+			},
+			expect: plusRE(`an error\n`, `err_fmt_test.go:\d+$`),
+		},
+		{
+			name: "clues.Err 3",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, 3)
+			},
+			expect: plusRE(`an error\n`, `testing/testing.go:\d+$`),
+		},
+		{
+			name: "clues.Err 4",
+			tracer: func(err *clues.Err) error {
+				return cluesWithTraceWrapper(err, 4)
+			},
+			expect: plusRE(`an error\n`, `runtime/.*:\d+$`),
+		},
+	}
+	for _, test := range table2 {
+		t.Run(test.name, func(t *testing.T) {
+			checkFmt{"%+v", "", regexp.MustCompile(test.expect)}.
+				check(t, test.tracer(cluErr))
+		})
+	}
+}
+
 func TestErrCore_String(t *testing.T) {
 	table := []struct {
 		name        string

--- a/err_test.go
+++ b/err_test.go
@@ -862,3 +862,51 @@ func TestStackNils(t *testing.T) {
 		t.Errorf("expected [%v], got [%v]", e, result)
 	}
 }
+
+func TestOrNil(t *testing.T) {
+	table := []struct {
+		name      string
+		err       *clues.Err
+		expectNil bool
+	}{
+		{
+			name:      "nil",
+			err:       nil,
+			expectNil: true,
+		},
+		{
+			name:      "nil stack",
+			err:       clues.Stack(nil).With("foo", "bar"),
+			expectNil: true,
+		},
+		{
+			name:      "nil wrap",
+			err:       clues.Wrap(nil, "msg").With("foo", "bar"),
+			expectNil: true,
+		},
+		{
+			name:      "nil",
+			err:       cluErr,
+			expectNil: false,
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			if test.expectNil != (test.err.OrNil() == nil) {
+				t.Errorf("nil state doesn't match expectations: got %v", test.err.OrNil())
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func withTraceWrapper(err error, depth int) error {
+	return clues.WithTrace(err, depth)
+}
+
+func cluesWithTraceWrapper(err *clues.Err, depth int) error {
+	return err.WithTrace(depth)
+}


### PR DESCRIPTION
withTrace allows the caller to override the trace message, for cases where error wrapping/stacking is offloaded to a deeper func to handle extra processing.

orNil ensures the error can return a nil value after wrapping and adding data to a nil error, instead of returning an interface holding a nil value.