### PR TITLE
fix concealing of concealers

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -111,11 +111,11 @@ func normalize(kvs ...any) map[string]any {
 	norm := map[string]any{}
 
 	for i := 0; i < len(kvs); i += 2 {
-		key := marshal(kvs[i])
+		key := marshal(kvs[i], true)
 
 		var value any
 		if i+1 < len(kvs) {
-			value = marshal(kvs[i+1])
+			value = marshal(kvs[i+1], true)
 		}
 
 		norm[key] = value
@@ -124,7 +124,7 @@ func normalize(kvs ...any) map[string]any {
 	return norm
 }
 
-func marshal(a any) string {
+func marshal(a any, conceal bool) string {
 	if a == nil {
 		return ""
 	}
@@ -135,7 +135,7 @@ func marshal(a any) string {
 		return ""
 	}
 
-	if as, ok := a.(Concealer); ok {
+	if as, ok := a.(Concealer); conceal && ok {
 		return as.Conceal()
 	}
 

--- a/clues_test.go
+++ b/clues_test.go
@@ -317,9 +317,7 @@ func TestImmutableCtx(t *testing.T) {
 	mustEquals(t, msa{"foo": "bar", "beaux": "regard"}, clues.In(lr).Map())
 }
 
-var (
-	_ clues.PlainConcealer = &safe{}
-)
+var _ clues.Concealer = &safe{}
 
 type safe struct {
 	v any
@@ -337,7 +335,7 @@ func (s safe) Conceal() string {
 	return string(bs)
 }
 
-var _ clues.PlainConcealer = &custom{}
+var _ clues.Concealer = &custom{}
 
 type custom struct {
 	a, b string

--- a/err.go
+++ b/err.go
@@ -686,7 +686,7 @@ func (ec *ErrCore) stringer(fancy bool) string {
 
 	vsl := []string{}
 	for k, v := range ec.Values {
-		vsl = append(vsl, k+":"+marshal(v))
+		vsl = append(vsl, k+":"+marshal(v, true))
 	}
 
 	vs := strings.Join(vsl, sep)

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -181,6 +181,76 @@ func TestHide(t *testing.T) {
 	}
 }
 
+func TestHide_hideAConcealer(t *testing.T) {
+	table := []struct {
+		name        string
+		input       any
+		expectHash  string
+		expectPlain string
+	}{
+		{
+			name:        "string",
+			input:       Hide("fnords"),
+			expectHash:  "7745164c2e6b3c97",
+			expectPlain: "fnords",
+		},
+		{
+			name:        "int",
+			input:       Hide(1),
+			expectHash:  "1e29272d274ab30f",
+			expectPlain: "1",
+		},
+		{
+			name:        "stringer",
+			input:       Hide(mockStringer{"fnords"}),
+			expectHash:  "553c83b5702ada92",
+			expectPlain: "{s:fnords}",
+		},
+		{
+			name:        "map",
+			input:       Hide(map[string]string{"fnords": "smarf"}),
+			expectHash:  "1502957923bb4cc8",
+			expectPlain: `{"fnords":"smarf"}`,
+		},
+		{
+			name:        "nil",
+			input:       Hide(nil),
+			expectHash:  "",
+			expectPlain: ``,
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			h := Hide(test.input)
+			if h.Conceal() != test.expectHash {
+				t.Errorf(`expected Conceal() result "%s", got "%s"`, test.expectHash, h.Conceal())
+			}
+			if h.String() != test.expectHash {
+				t.Errorf(`expected String() result "%s", got "%s"`, test.expectHash, h.String())
+			}
+			if h.PlainString() != test.expectPlain {
+				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, h.PlainString())
+			}
+			result := fmt.Sprintf("%s", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%s fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%v fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%+v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%+v fmt result "%s", got "%s`, test.expectHash, result)
+			}
+			result = fmt.Sprintf("%#v", h)
+			if result != test.expectHash {
+				t.Errorf(`expected %%#v fmt result "%s", got "%s`, test.expectHash, result)
+			}
+		})
+	}
+}
+
 func TestHideAll(t *testing.T) {
 	table := []struct {
 		name        string


### PR DESCRIPTION
ensures that passing a concealer to clues.Hide() doesn't double-hash the values.  Also adds some minor cleanup like var renaming in the secret struct, and combines the Concealer and PlainStringer interfaces.