### PR TITLE
un-slice data when marshalling

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -2,7 +2,6 @@ package clues
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -171,12 +170,7 @@ func marshal(a any, conceal bool) string {
 		return as.String()
 	}
 
-	bs, err := json.Marshal(a)
-	if err != nil {
-		return "marshalling clue: " + err.Error()
-	}
-
-	return string(bs)
+	return fmt.Sprintf("%+v", a)
 }
 
 // Add adds all key-value pairs to the clues.

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -44,7 +44,7 @@ func TestConceal(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := ConcealWith(test.alg, input)
 			if result != test.expect {
-				t.Errorf(`expected hash result "%s", got "%s"`, test.expect, result)
+				t.Errorf(`expected hash result %q, got %q`, test.expect, result)
 			}
 		})
 	}
@@ -69,7 +69,7 @@ func TestMask(t *testing.T) {
 		{
 			name:        "map",
 			input:       map[string]string{"fnords": "smarf"},
-			expectPlain: `{"fnords":"smarf"}`,
+			expectPlain: `map[fnords:smarf]`,
 		},
 		{
 			name:        "nil",
@@ -83,29 +83,29 @@ func TestMask(t *testing.T) {
 
 			m := Mask(test.input)
 			if m.Conceal() != expect {
-				t.Errorf(`expected Conceal() result "%s", got "%s"`, expect, m.Conceal())
+				t.Errorf(`expected Conceal() result %q, got %q`, expect, m.Conceal())
 			}
 			if m.String() != expect {
-				t.Errorf(`expected String() result "%s", got "%s"`, expect, m.String())
+				t.Errorf(`expected String() result %q, got %q`, expect, m.String())
 			}
 			if m.PlainString() != test.expectPlain {
-				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, m.PlainString())
+				t.Errorf(`expected PlainString() result %q, got %q`, test.expectPlain, m.PlainString())
 			}
 			result := fmt.Sprintf("%s", m)
 			if result != expect {
-				t.Errorf(`expected %%s fmt result "%s", got "%s`, expect, result)
+				t.Errorf(`expected %%s fmt result %q, got %q`, expect, result)
 			}
 			result = fmt.Sprintf("%v", m)
 			if result != expect {
-				t.Errorf(`expected %%v fmt result "%s", got "%s`, expect, result)
+				t.Errorf(`expected %%v fmt result %q, got %q`, expect, result)
 			}
 			result = fmt.Sprintf("%+v", m)
 			if result != expect {
-				t.Errorf(`expected %%+v fmt result "%s", got "%s`, expect, result)
+				t.Errorf(`expected %%+v fmt result %q, got %q`, expect, result)
 			}
 			result = fmt.Sprintf("%#v", m)
 			if result != expect {
-				t.Errorf(`expected %%#v fmt result "%s", got "%s`, expect, result)
+				t.Errorf(`expected %%#v fmt result %q, got %q`, expect, result)
 			}
 		})
 	}
@@ -139,8 +139,8 @@ func TestHide(t *testing.T) {
 		{
 			name:        "map",
 			input:       map[string]string{"fnords": "smarf"},
-			expectHash:  "1502957923bb4cc8",
-			expectPlain: `{"fnords":"smarf"}`,
+			expectHash:  "e9e09313140d3c4e",
+			expectPlain: `map[fnords:smarf]`,
 		},
 		{
 			name:        "nil",
@@ -153,29 +153,29 @@ func TestHide(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			h := Hide(test.input)
 			if h.Conceal() != test.expectHash {
-				t.Errorf(`expected Conceal() result "%s", got "%s"`, test.expectHash, h.Conceal())
+				t.Errorf(`expected Conceal() result %q, got %q`, test.expectHash, h.Conceal())
 			}
 			if h.String() != test.expectHash {
-				t.Errorf(`expected String() result "%s", got "%s"`, test.expectHash, h.String())
+				t.Errorf(`expected String() result %q, got %q`, test.expectHash, h.String())
 			}
 			if h.PlainString() != test.expectPlain {
-				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, h.PlainString())
+				t.Errorf(`expected PlainString() result %q, got %q`, test.expectPlain, h.PlainString())
 			}
 			result := fmt.Sprintf("%s", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%s fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%s fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%v fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%+v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%+v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%+v fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%#v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%#v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%#v fmt result %q, got %q`, test.expectHash, result)
 			}
 		})
 	}
@@ -209,8 +209,8 @@ func TestHide_hideAConcealer(t *testing.T) {
 		{
 			name:        "map",
 			input:       Hide(map[string]string{"fnords": "smarf"}),
-			expectHash:  "1502957923bb4cc8",
-			expectPlain: `{"fnords":"smarf"}`,
+			expectHash:  "e9e09313140d3c4e",
+			expectPlain: `map[fnords:smarf]`,
 		},
 		{
 			name:        "nil",
@@ -223,29 +223,29 @@ func TestHide_hideAConcealer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			h := Hide(test.input)
 			if h.Conceal() != test.expectHash {
-				t.Errorf(`expected Conceal() result "%s", got "%s"`, test.expectHash, h.Conceal())
+				t.Errorf(`expected Conceal() result %q, got %q`, test.expectHash, h.Conceal())
 			}
 			if h.String() != test.expectHash {
-				t.Errorf(`expected String() result "%s", got "%s"`, test.expectHash, h.String())
+				t.Errorf(`expected String() result %q, got %q`, test.expectHash, h.String())
 			}
 			if h.PlainString() != test.expectPlain {
-				t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain, h.PlainString())
+				t.Errorf(`expected PlainString() result %q, got %q`, test.expectPlain, h.PlainString())
 			}
 			result := fmt.Sprintf("%s", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%s fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%s fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%v fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%+v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%+v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%+v fmt result %q, got %q`, test.expectHash, result)
 			}
 			result = fmt.Sprintf("%#v", h)
 			if result != test.expectHash {
-				t.Errorf(`expected %%#v fmt result "%s", got "%s`, test.expectHash, result)
+				t.Errorf(`expected %%#v fmt result %q, got %q`, test.expectHash, result)
 			}
 		})
 	}
@@ -273,8 +273,8 @@ func TestHideAll(t *testing.T) {
 		{
 			name:        "map",
 			input:       []any{map[string]string{"fnords": "smarf"}},
-			expectHash:  []string{"1502957923bb4cc8"},
-			expectPlain: []string{`{"fnords":"smarf"}`},
+			expectHash:  []string{"e9e09313140d3c4e"},
+			expectPlain: []string{`map[fnords:smarf]`},
 		},
 		{
 			name:        "nil",
@@ -290,13 +290,13 @@ func TestHideAll(t *testing.T) {
 				expectHash := test.expectHash[i]
 
 				if h.Conceal() != expectHash {
-					t.Errorf(`expected Conceal() result "%s", got "%s"`, expectHash, h.Conceal())
+					t.Errorf(`expected Conceal() result %q, got %q`, expectHash, h.Conceal())
 				}
 				if h.String() != expectHash {
-					t.Errorf(`expected String() result "%s", got "%s"`, expectHash, h.String())
+					t.Errorf(`expected String() result %q, got %q`, expectHash, h.String())
 				}
 				if h.PlainString() != test.expectPlain[i] {
-					t.Errorf(`expected PlainString() result "%s", got "%s"`, test.expectPlain[i], h.String())
+					t.Errorf(`expected PlainString() result %q, got %q`, test.expectPlain[i], h.String())
 				}
 			}
 		})


### PR DESCRIPTION
clues is slicing data when marshalling, due to using JSON.marshal instead of fmt %+v during the data stringifying step. This change swaps to the fmt so that user's don't need to export and tag their structures for clues inclusion.