### PR TITLE
Fix label check and add test

### DIFF
--- a/err.go
+++ b/err.go
@@ -118,7 +118,10 @@ func (err *Err) HasLabel(label string) bool {
 		return false
 	}
 
-	if _, ok := err.labels[label]; ok {
+	// Check all labels in the error and it's stack since the stack isn't
+	// traversed separately. If we don't check the stacked labels here we'll skip
+	// checking them completely.
+	if _, ok := err.Labels()[label]; ok {
 		return true
 	}
 

--- a/err_test.go
+++ b/err_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
 
 	"github.com/alcionai/clues"
 )
@@ -105,6 +106,43 @@ func TestStack(t *testing.T) {
 				t.Errorf("expected nil error but got: %+v\n", err)
 			} else if !test.expectNil && err == nil {
 				t.Error("expected non-nil error but got nil")
+			}
+		})
+	}
+}
+
+func TestHasLabel(t *testing.T) {
+	const label = "some-label"
+
+	table := []struct {
+		name    string
+		initial error
+	}{
+		{
+			name: "multiple stacked clues errors with label on first",
+			initial: clues.Stack(
+				clues.New("Labeled").Label(label),
+				clues.New("NotLabeled")),
+		},
+		{
+			name: "multiple stacked clues errors with label on second",
+			initial: clues.Stack(
+				clues.New("NotLabeled"),
+				clues.New("Labeled").Label(label)),
+		},
+		{
+			name:    "single stacked clues error with label",
+			initial: clues.Stack(clues.New("Labeled").Label(label)),
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			if !clues.HasLabel(test.initial, label) {
+				t.Errorf(
+					"expected error to have label [%s] but got %v",
+					label,
+					maps.Keys(clues.Labels(test.initial)))
 			}
 		})
 	}


### PR DESCRIPTION
Implementation was originally only comparing against the labels in the top-level error. Therefore, if the label existed in one of the stacked errors it wouldn't be found if > 1 error was passed to `clues.Stack()` but would be reported by `clues.Labels()`