### PR TITLE
add StackWrap

### DIFF
--- a/err_test.go
+++ b/err_test.go
@@ -788,6 +788,13 @@ var testTable = []struct {
 		expectValues: msa{},
 	},
 	{
+		name:         "stackwrap",
+		err:          clues.StackWrap(target, sentinel, "wrap"),
+		expectMsg:    "target: wrap: sentinel",
+		expectLabels: msa{},
+		expectValues: msa{},
+	},
+	{
 		name:         "wrap two stack: top",
 		err:          clues.Wrap(clues.Stack(target, sentinel, other), "wrap"),
 		expectMsg:    "wrap: target: sentinel: other",

--- a/err_test.go
+++ b/err_test.go
@@ -795,6 +795,13 @@ var testTable = []struct {
 		expectValues: msa{},
 	},
 	{
+		name:         "stackwrapWC",
+		err:          clues.StackWrapWC(context.Background(), target, sentinel, "wrap"),
+		expectMsg:    "target: wrap: sentinel",
+		expectLabels: msa{},
+		expectValues: msa{},
+	},
+	{
 		name:         "wrap two stack: top",
 		err:          clues.Wrap(clues.Stack(target, sentinel, other), "wrap"),
 		expectMsg:    "wrap: target: sentinel: other",


### PR DESCRIPTION
adds a StackWrap func, which is a quality of life shorthand replacing:
`clues.Stack(sentinel, clues.Wrap(err, "some message"))`
with:
`clues.StackWrap(sentinel, err, "some message")`