### PR TITLE
add Comments to the clues package

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"path"
 	"reflect"
-	"slices"
 	"strings"
 
 	"github.com/google/uuid"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
 
 type Adder interface {

--- a/clues.go
+++ b/clues.go
@@ -3,7 +3,9 @@ package clues
 import (
 	"context"
 	"fmt"
+	"path"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -34,6 +36,7 @@ type dataNode struct {
 	id           string
 	vs           map[string]any
 	labelCounter Adder
+	comment      comment
 }
 
 func makeNodeID() string {
@@ -113,6 +116,85 @@ func (dn *dataNode) Map() map[string]any {
 	}
 
 	return m
+}
+
+type comment struct {
+	Caller  string
+	Dir     string
+	File    string
+	Message string
+}
+
+func (c comment) isEmpty() bool {
+	return len(c.Message) == 0
+}
+
+func newComment(
+	depth int,
+	template string,
+	values ...any,
+) comment {
+	caller := getCaller(depth + 1)
+	longTrace := getTrace(depth + 1)
+	dir, file := path.Split(longTrace)
+
+	return comment{
+		Caller:  caller,
+		Dir:     dir,
+		File:    file,
+		Message: fmt.Sprintf(template, values...),
+	}
+}
+
+func (dn *dataNode) addComment(
+	depth int,
+	msg string,
+	vs ...any,
+) *dataNode {
+	if len(msg) == 0 {
+		return dn
+	}
+
+	return &dataNode{
+		parent:       dn,
+		labelCounter: dn.labelCounter,
+		comment:      newComment(depth+1, msg, vs...),
+	}
+}
+
+type comments []comment
+
+func (cs comments) String() string {
+	result := []string{}
+
+	for _, c := range cs {
+		result = append(result, c.Caller+" - "+c.File)
+		result = append(result, "\t"+c.Message)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// Comments retrieves the full ancestor comment chain.
+// The return value is ordered from the first added comment
+// to the last one.
+func (dn *dataNode) Comments() comments {
+	result := comments{}
+
+	if !dn.comment.isEmpty() {
+		result = append(result, dn.comment)
+	}
+
+	for dn.parent != nil {
+		dn = dn.parent
+		if !dn.comment.isEmpty() {
+			result = append(result, dn.comment)
+		}
+	}
+
+	slices.Reverse(result)
+
+	return result
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +381,32 @@ func AddLabelCounter(ctx context.Context, counter Adder) context.Context {
 	nc := from(ctx, defaultNamespace)
 	nn := nc.add(nil)
 	nn.labelCounter = counter
+	return set(ctx, nn)
+}
+
+// Comments are special case additions to the context.  They're here to, well,
+// let you add comments!  Why?  Because sometimes it's not sufficient to have a
+// log let you know that a line of code was reached. Even a bunch of clues to
+// describe system state may not be enough.  Sometimes what you need in order
+// to debug the situation is a long-form explanation (you do already add that
+// to your code, don't you?).  Or, even better, a linear history of long-form
+// explanations, each one building on the prior (which you can't easily do in
+// code).
+//
+// Should you transfer all your comments to clues?  Absolutely not.  But in
+// cases where extra explantion is truly important to debugging production,
+// when all you've got are some logs and (maybe if you're lucky) a span trace?
+// Those are the ones you want.
+//
+// Unlike other additions, which are added as top-level key:value pairs to the
+// context, comments are all held as a single array of additions, persisted in
+// order of appearance, and prefixed by the file and line in which they appeared.
+// This means comments are always added to the context and never clobber each
+// other, regardless of their location.  IE: don't add them to a loop.
+func AddComment(ctx context.Context, msg string, vs ...any) context.Context {
+	nc := from(ctx, defaultNamespace)
+	nn := nc.addComment(1, msg, vs...)
+
 	return set(ctx, nn)
 }
 

--- a/err.go
+++ b/err.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"reflect"
 	"runtime"
 	"strings"
@@ -76,6 +77,23 @@ func toStack(e error, stack []error, traceDepth int) *Err {
 func getTrace(depth int) string {
 	_, file, line, _ := runtime.Caller(depth + 1)
 	return fmt.Sprintf("%s:%d", file, line)
+}
+
+func getCaller(depth int) string {
+	pc, _, _, ok := runtime.Caller(depth + 1)
+	if !ok {
+		return ""
+	}
+
+	funcPath := runtime.FuncForPC(pc).Name()
+	base := path.Base(funcPath)
+	parts := strings.Split(base, ".")
+
+	if len(parts) < 2 {
+		return base
+	}
+
+	return parts[len(parts)-1]
 }
 
 func getLabelCounter(e error) Adder {
@@ -344,6 +362,58 @@ func WithClues(err error, ctx context.Context) *Err {
 	return WithMap(err, In(ctx).Map())
 }
 
+// Comments are special case additions to the error.  They're here to, well,
+// let you add comments!  Why?  Because sometimes it's not sufficient to have
+// an error message describe what that error really means. Even a bunch of
+// clues  to describe system state may not be enough.  Sometimes what you need
+// in order to debug the situation is a long-form explanation (you do already
+// add that to your code, don't you?).  Or, even better, a linear history of
+// long-form explanations, each one building on the prior (which you can't
+// easily do in code).
+//
+// Unlike other additions, which are added as top-level key:value pairs to the
+// context, the whole history of comments gets retained, persisted in order of
+// appearance and prefixed by the file and line in which they appeared. This
+// means comments are always added to the error and never clobber each other,
+// regardless of their location.
+func (err *Err) WithComment(msg string, vs ...any) *Err {
+	if isNilErrIface(err) {
+		return nil
+	}
+
+	return &Err{
+		e: err,
+		// have to do a new dataNode here, or else comments will duplicate
+		data: &dataNode{comment: newComment(1, msg, vs...)},
+	}
+}
+
+// Comments are special case additions to the error.  They're here to, well,
+// let you add comments!  Why?  Because sometimes it's not sufficient to have
+// an error message describe what that error really means. Even a bunch of
+// clues  to describe system state may not be enough.  Sometimes what you need
+// in order to debug the situation is a long-form explanation (you do already
+// add that to your code, don't you?).  Or, even better, a linear history of
+// long-form explanations, each one building on the prior (which you can't
+// easily do in code).
+//
+// Unlike other additions, which are added as top-level key:value pairs to the
+// context, the whole history of comments gets retained, persisted in order of
+// appearance and prefixed by the file and line in which they appeared. This
+// means comments are always added to the error and never clobber each other,
+// regardless of their location.
+func WithComment(err error, msg string, vs ...any) *Err {
+	if isNilErrIface(err) {
+		return nil
+	}
+
+	return &Err{
+		e: err,
+		// have to do a new dataNode here, or else comments will duplicate
+		data: &dataNode{comment: newComment(1, msg, vs...)},
+	}
+}
+
 // OrNil is a workaround for golang's infamous "an interface
 // holding a nil value is not nil" gotcha.  You can use it at
 // the end of error formatting chains to ensure a correct nil
@@ -382,6 +452,71 @@ func (err *Err) values() map[string]any {
 	}
 
 	return vals
+}
+
+// Comments retrieves all comments in the error.
+func (err *Err) Comments() comments {
+	return Comments(err)
+}
+
+// Comments retrieves all comments in the error.
+func Comments(err error) comments {
+	if isNilErrIface(err) {
+		return comments{}
+	}
+
+	ancs := ancestors(err)
+	result := comments{}
+
+	for _, ancestor := range ancs {
+		ce, ok := ancestor.(*Err)
+		if !ok {
+			continue
+		}
+
+		result = append(result, ce.data.Comments()...)
+	}
+
+	return result
+}
+
+// TODO: this will need some cleanup in a follow-up PR.
+//
+// ancestors builds out the ancestor lineage of this
+// particular error.  This follows standard layout rules
+// already established elsewhere:
+// * the first entry is the oldest ancestor, the last is
+// the current error.
+// * Stacked errors get visited before wrapped errors.
+func ancestors(err error) []error {
+	return stackAncestorsOntoSelf(err)
+}
+
+// a recursive function, purely for building out ancestorStack.
+func stackAncestorsOntoSelf(err error) []error {
+	if err == nil {
+		return []error{}
+	}
+
+	errs := []error{}
+
+	ce, ok := err.(*Err)
+
+	if ok {
+		for _, e := range ce.stack {
+			errs = append(errs, stackAncestorsOntoSelf(e)...)
+		}
+	}
+
+	unwrapped := Unwrap(err)
+
+	if unwrapped != nil {
+		errs = append(errs, stackAncestorsOntoSelf(unwrapped)...)
+	}
+
+	errs = append(errs, err)
+
+	return errs
 }
 
 // InErr returns the map of contextual values in the error.

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1420,7 +1420,7 @@ func TestWithTrace(t *testing.T) {
 		expectStacked string
 	}{
 		{
-			name: "clues.Err -1",
+			name: "clues.Err 1",
 			tracer: func(err *clues.Err) error {
 				return cluesWithTraceWrapper(err, -1)
 			},
@@ -1525,6 +1525,141 @@ func TestWithTrace(t *testing.T) {
 			t.Run("stack", func(t *testing.T) {
 				checkFmt{"%+v", "", regexp.MustCompile(test.expectStacked)}.
 					check(t, clues.Stack(cluErr, test.tracer(cluErr)))
+			})
+		})
+	}
+}
+
+func TestWithComment(t *testing.T) {
+	table := []struct {
+		name          string
+		commenter     func(err error) error
+		expect        string
+		expectWrapped string
+		expectStacked string
+	}{
+		{
+			name: "error flat comment",
+			commenter: func(err error) error {
+				return withCommentWrapper(err, "fisher")
+			},
+			expect: commentRE(
+				`withCommentWrapper`, `err_test.go`, `fisher`,
+				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+			expectWrapped: commentRE(
+				`withCommentWrapper`, `err_test.go`, `fisher`,
+				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+			expectStacked: commentRE(
+				`withCommentWrapper`, `err_test.go`, `fisher`,
+				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+		},
+		{
+			name: "error formatted comment",
+			commenter: func(err error) error {
+				return withCommentWrapper(err, "%d", 42)
+			},
+			expect: commentRE(
+				`withCommentWrapper`, `err_test.go`, `42`,
+				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+			expectWrapped: commentRE(
+				`withCommentWrapper`, `err_test.go`, `42`,
+				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+			expectStacked: commentRE(
+				`withCommentWrapper`, `err_test.go`, `42`,
+				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+		},
+	}
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("plain error", func(t *testing.T) {
+				comments := clues.Comments(test.commenter(cluErr)).String()
+				commentMatches(t, test.expect, comments)
+			})
+			t.Run("wrapWC", func(t *testing.T) {
+				err := clues.WrapWC(context.Background(), test.commenter(cluErr), "wrap")
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectWrapped, comments)
+			})
+			t.Run("wrap", func(t *testing.T) {
+				err := clues.Wrap(test.commenter(cluErr), "wrap")
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectWrapped, comments)
+			})
+			t.Run("stackWC", func(t *testing.T) {
+				err := clues.StackWC(context.Background(), cluErr, test.commenter(cluErr))
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectStacked, comments)
+			})
+			t.Run("stack", func(t *testing.T) {
+				err := clues.Stack(cluErr, test.commenter(cluErr))
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectStacked, comments)
+			})
+		})
+	}
+	table2 := []struct {
+		name          string
+		commenter     func(err *clues.Err) error
+		expect        string
+		expectWrapped string
+		expectStacked string
+	}{
+		{
+			name: "clues.Err flat comment",
+			commenter: func(err *clues.Err) error {
+				return cluesWithCommentWrapper(err, "fisher")
+			},
+			expect: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+			expectWrapped: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+			expectStacked: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+		},
+		{
+			name: "clues.Err formatted comment",
+			commenter: func(err *clues.Err) error {
+				return cluesWithCommentWrapper(err, "%d", 42)
+			},
+			expect: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+			expectWrapped: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+			expectStacked: commentRE(
+				`cluesWithCommentWrapper`, `err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+		},
+	}
+	for _, test := range table2 {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("plain error", func(t *testing.T) {
+				comments := clues.Comments(test.commenter(cluErr)).String()
+				commentMatches(t, test.expect, comments)
+			})
+			t.Run("wrapWC", func(t *testing.T) {
+				err := clues.WrapWC(context.Background(), test.commenter(cluErr), "wrap")
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectWrapped, comments)
+			})
+			t.Run("wrap", func(t *testing.T) {
+				err := clues.Wrap(test.commenter(cluErr), "wrap")
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectWrapped, comments)
+			})
+			t.Run("stackWC", func(t *testing.T) {
+				err := clues.StackWC(context.Background(), cluErr, test.commenter(cluErr))
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectStacked, comments)
+			})
+			t.Run("stack", func(t *testing.T) {
+				err := clues.Stack(cluErr, test.commenter(cluErr))
+				comments := clues.Comments(err).String()
+				commentMatches(t, test.expectStacked, comments)
 			})
 		})
 	}

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1686,7 +1686,7 @@ func TestErrCore_String(t *testing.T) {
 				Label("label").
 				Core(),
 			expectS:     `{"message", [label], {key:value}}`,
-			expectVPlus: `{msg:"message", labels:[label], values:{key:value}}`,
+			expectVPlus: `{msg:"message", labels:[label], values:{key:value}, comments:[]}`,
 		},
 		{
 			name: "message only",
@@ -1694,7 +1694,7 @@ func TestErrCore_String(t *testing.T) {
 				New("message").
 				Core(),
 			expectS:     `{"message"}`,
-			expectVPlus: `{msg:"message", labels:[], values:{}}`,
+			expectVPlus: `{msg:"message", labels:[], values:{}, comments:[]}`,
 		},
 		{
 			name: "labels only",
@@ -1703,7 +1703,7 @@ func TestErrCore_String(t *testing.T) {
 				Label("label").
 				Core(),
 			expectS:     `{[label]}`,
-			expectVPlus: `{msg:"", labels:[label], values:{}}`,
+			expectVPlus: `{msg:"", labels:[label], values:{}, comments:[]}`,
 		},
 		{
 			name: "values only",
@@ -1712,7 +1712,7 @@ func TestErrCore_String(t *testing.T) {
 				With("key", "value").
 				Core(),
 			expectS:     `{{key:value}}`,
-			expectVPlus: `{msg:"", labels:[], values:{key:value}}`,
+			expectVPlus: `{msg:"", labels:[], values:{key:value}, comments:[]}`,
 		},
 	}
 	for _, test := range table {

--- a/err_test.go
+++ b/err_test.go
@@ -1346,3 +1346,25 @@ func withTraceWrapper(err error, depth int) error {
 func cluesWithTraceWrapper(err *clues.Err, depth int) error {
 	return err.WithTrace(depth)
 }
+
+func withCommentWrapper(
+	err error,
+	msg string,
+	vs ...any,
+) error {
+	// always add two comments to test that both are saved
+	return clues.
+		WithComment(err, msg, vs...).
+		WithComment(msg+" - repeat", vs...)
+}
+
+func cluesWithCommentWrapper(
+	err *clues.Err,
+	msg string,
+	vs ...any,
+) error {
+	// always add two comments to test that both are saved
+	return err.
+		WithComment(msg, vs...).
+		WithComment(msg+" - repeat", vs...)
+}


### PR DESCRIPTION
Comments provide a space for long-form commenting around a chain of
    processes.  Whether as a way to augment the conditions of hitting a
    certain process, or as a way to further explain a given error, this
    adddion splits the needs of short-form identifiers (such as the error
    message) and long form explanation into their own compartments.