### PR TITLE
Improve the error trace

### DIFF
--- a/clues_test.go
+++ b/clues_test.go
@@ -677,9 +677,9 @@ func TestAddComment_trace(t *testing.T) {
 	comments := dn.Comments()
 	stack := comments.String()
 	expected := commentRE(
-		"TestAddComment_trace", "clues_test.go", "one",
-		"addCommentToCtx", "clues_test.go", "two",
-		"TestAddComment_trace", "clues_test.go", `three$`)
+		"TestAddComment_trace", "clues/clues_test.go", "one",
+		"addCommentToCtx", "clues/clues_test.go", "two",
+		"TestAddComment_trace", "clues/clues_test.go", `three$`)
 
 	commentMatches(t, expected, stack)
 }

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1544,14 +1544,14 @@ func TestWithComment(t *testing.T) {
 				return withCommentWrapper(err, "fisher")
 			},
 			expect: commentRE(
-				`withCommentWrapper`, `err_test.go`, `fisher`,
-				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`withCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 			expectWrapped: commentRE(
-				`withCommentWrapper`, `err_test.go`, `fisher`,
-				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`withCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 			expectStacked: commentRE(
-				`withCommentWrapper`, `err_test.go`, `fisher`,
-				`withCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`withCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 		},
 		{
 			name: "error formatted comment",
@@ -1559,14 +1559,14 @@ func TestWithComment(t *testing.T) {
 				return withCommentWrapper(err, "%d", 42)
 			},
 			expect: commentRE(
-				`withCommentWrapper`, `err_test.go`, `42`,
-				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `42`,
+				`withCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 			expectWrapped: commentRE(
-				`withCommentWrapper`, `err_test.go`, `42`,
-				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `42`,
+				`withCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 			expectStacked: commentRE(
-				`withCommentWrapper`, `err_test.go`, `42`,
-				`withCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`withCommentWrapper`, `clues/err_test.go`, `42`,
+				`withCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 		},
 	}
 	for _, test := range table {
@@ -1610,14 +1610,14 @@ func TestWithComment(t *testing.T) {
 				return cluesWithCommentWrapper(err, "fisher")
 			},
 			expect: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 			expectWrapped: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 			expectStacked: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher`,
-				`cluesWithCommentWrapper`, `err_test.go`, `fisher - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `fisher - repeat$`),
 		},
 		{
 			name: "clues.Err formatted comment",
@@ -1625,14 +1625,14 @@ func TestWithComment(t *testing.T) {
 				return cluesWithCommentWrapper(err, "%d", 42)
 			},
 			expect: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `42`,
-				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 			expectWrapped: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `42`,
-				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 			expectStacked: commentRE(
-				`cluesWithCommentWrapper`, `err_test.go`, `42`,
-				`cluesWithCommentWrapper`, `err_test.go`, `42 - repeat$`),
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42`,
+				`cluesWithCommentWrapper`, `clues/err_test.go`, `42 - repeat$`),
 		},
 	}
 	for _, test := range table2 {


### PR DESCRIPTION
instead of printing out the absolute Path for each error (which is a bit overkill in most situations), instead write the func name, and the parentdir + file:line where the error was generated or wrapped.