### PR TITLE
introduce Proxy functionality

### DIFF
--- a/err.go
+++ b/err.go
@@ -63,10 +63,7 @@ func newErr(
 		file:   file,
 		caller: getCaller(traceDepth + 1),
 		msg:    msg,
-		data: &dataNode{
-			id:     makeNodeID(),
-			values: m,
-		},
+		data:   &dataNode{values: m},
 	}
 }
 
@@ -106,10 +103,7 @@ func toStack(
 		file:   file,
 		caller: getCaller(traceDepth + 1),
 		stack:  stack,
-		data: &dataNode{
-			id:     makeNodeID(),
-			values: map[string]any{},
-		},
+		data:   &dataNode{values: map[string]any{}},
 	}
 }
 

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1720,7 +1720,9 @@ func TestErrCore_String(t *testing.T) {
 			tc := test.core
 			if tc != nil {
 				if _, ok := tc.Values["clues_trace"]; !ok {
-					t.Error("expected core values to contain key [clues_trace]")
+					t.Errorf(
+						"expected core values to contain key [clues_trace]\ngot: %+v",
+						tc.Values)
 				}
 				delete(tc.Values, "clues_trace")
 			}


### PR DESCRIPTION
Ads a new feature to clues: proxies.  A proxy is a way to ensure clues additions are not lost in cases where downstream or adhoc funcs are unable to retrieve those values or pass them back through a clues.Err. By adding a proxy, a higher level instance also receives downstream additions.