### PR TITLE
add witnesses

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -194,7 +194,49 @@ func AddCommentTo(
 }
 
 // ---------------------------------------------------------------------------
-// hooks
+// witness
+// ---------------------------------------------------------------------------
+
+// AddWitness adds a witness with a given name to the contex.  The caller can
+// pass the witness clues directly in a downstream instance to add those clues
+// to the current clues node.  This can be handy in a certain set of uncommon
+// cases where retrieving clues is otherwise difficult to do, such as working
+// with middleware that doesn't allow control over error creation.
+//
+// When retreiving clues from a context, each witness will produce its own
+// namespaced set of values
+func AddWitness(
+	ctx context.Context,
+	name string,
+) context.Context {
+	nc := nodeFromCtx(ctx, defaultNamespace)
+	nn := nc.addWitness(name)
+
+	return setDefaultNodeInCtx(ctx, nn)
+}
+
+// Relay adds all key-value pairs to the provided witness.  The witness will
+// record those values to the dataNode in which it was created.  All relayed
+// values are namespaced to the owning witness.
+func Relay(
+	ctx context.Context,
+	witness string,
+	vs ...any,
+) {
+	nc := nodeFromCtx(ctx, defaultNamespace)
+	wit, ok := nc.witnesses[witness]
+
+	if !ok {
+		return
+	}
+
+	// set values, not add.  We don't want witnesses
+	// to own a full clues tree.
+	wit.data.setValues(normalize(vs...))
+}
+
+// ---------------------------------------------------------------------------
+// error label counter
 // ---------------------------------------------------------------------------
 
 // AddLabelCounter embeds an Adder interface into this context. Any already

--- a/clues.go
+++ b/clues.go
@@ -194,45 +194,49 @@ func AddCommentTo(
 }
 
 // ---------------------------------------------------------------------------
-// witness
+// agents
 // ---------------------------------------------------------------------------
 
-// AddWitness adds a witness with a given name to the contex.  The caller can
-// pass the witness clues directly in a downstream instance to add those clues
-// to the current clues node.  This can be handy in a certain set of uncommon
-// cases where retrieving clues is otherwise difficult to do, such as working
-// with middleware that doesn't allow control over error creation.
+// AddAgent adds an agent with a given name to the context.  What's an agent?
+// It's a special case info gatherer that you can spawn to collect clues for
+// you.  Unlike standard clues additions, you have to tell the agent exactly
+// what data you want it to Gather() for you.
 //
-// When retreiving clues from a context, each witness will produce its own
-// namespaced set of values
-func AddWitness(
+// Agents are recorded in the current clues node and all of its descendants.
+// Data gathered by the agent will appear as part of the standard data map,
+// namespaced by each agent.
+//
+// Agents are specifically handy in a certain set of uncommon cases where
+// retrieving clues is otherwise difficult to do, such as working with
+// middleware that doesn't allow control over error creation.  In these cases
+// your only option is to relay that data back to some prior clues node.
+func AddAgent(
 	ctx context.Context,
 	name string,
 ) context.Context {
 	nc := nodeFromCtx(ctx, defaultNamespace)
-	nn := nc.addWitness(name)
+	nn := nc.addAgent(name)
 
 	return setDefaultNodeInCtx(ctx, nn)
 }
 
-// Relay adds all key-value pairs to the provided witness.  The witness will
-// record those values to the dataNode in which it was created.  All relayed
-// values are namespaced to the owning witness.
-func Relay(
+// Gather adds all key-value pairs to the provided agent.  The agent will
+// record those values to the dataNode in which it was created.  All gathered
+// values are namespaced to the owning agent.
+func Gather(
 	ctx context.Context,
-	witness string,
+	agent string,
 	vs ...any,
 ) {
 	nc := nodeFromCtx(ctx, defaultNamespace)
-	wit, ok := nc.witnesses[witness]
+	ag, ok := nc.agents[agent]
 
 	if !ok {
 		return
 	}
 
-	// set values, not add.  We don't want witnesses
-	// to own a full clues tree.
-	wit.data.setValues(normalize(vs...))
+	// set values, not add.  We don't want agents to own a full clues tree.
+	ag.data.setValues(normalize(vs...))
 }
 
 // ---------------------------------------------------------------------------

--- a/clues_test.go
+++ b/clues_test.go
@@ -699,7 +699,7 @@ func TestAddComment_trace(t *testing.T) {
 	commentMatches(t, expected, stack)
 }
 
-func TestAddWitness(t *testing.T) {
+func TestAddAgent(t *testing.T) {
 	ctx := context.Background()
 	ctx = clues.Add(ctx, "one", 1)
 
@@ -707,9 +707,9 @@ func TestAddWitness(t *testing.T) {
 		"one": 1,
 	}, true)
 
-	ctxWithWit := clues.AddWitness(ctx, "wit")
-	clues.Relay(ctx, "wit", "zero", 0)
-	clues.Relay(ctxWithWit, "wit", "two", 2)
+	ctxWithWit := clues.AddAgent(ctx, "wit")
+	clues.Gather(ctx, "wit", "zero", 0)
+	clues.Gather(ctxWithWit, "wit", "two", 2)
 
 	mapEquals(t, ctx, msa{
 		"one": 1,
@@ -717,15 +717,15 @@ func TestAddWitness(t *testing.T) {
 
 	mapEquals(t, ctxWithWit, msa{
 		"one": 1,
-		"witnessed": map[string]map[string]any{
+		"agents": map[string]map[string]any{
 			"wit": {
 				"two": 2,
 			},
 		},
 	}, true)
 
-	ctxWithTim := clues.AddWitness(ctxWithWit, "tim")
-	clues.Relay(ctxWithTim, "tim", "three", 3)
+	ctxWithTim := clues.AddAgent(ctxWithWit, "tim")
+	clues.Gather(ctxWithTim, "tim", "three", 3)
 
 	mapEquals(t, ctx, msa{
 		"one": 1,
@@ -733,7 +733,7 @@ func TestAddWitness(t *testing.T) {
 
 	mapEquals(t, ctxWithTim, msa{
 		"one": 1,
-		"witnessed": map[string]map[string]any{
+		"agents": map[string]map[string]any{
 			"wit": {
 				"two": 2,
 			},
@@ -743,16 +743,39 @@ func TestAddWitness(t *testing.T) {
 		},
 	}, true)
 
-	ctxWithBob := clues.AddWitness(ctx, "bob")
-	clues.Relay(ctxWithBob, "bob", "four", 4)
+	ctxWithBob := clues.AddAgent(ctx, "bob")
+	clues.Gather(ctxWithBob, "bob", "four", 4)
 
 	mapEquals(t, ctx, msa{
 		"one": 1,
 	}, true)
 
+	// should not have changed since its first usage
+	mapEquals(t, ctxWithWit, msa{
+		"one": 1,
+		"agents": map[string]map[string]any{
+			"wit": {
+				"two": 2,
+			},
+		},
+	}, true)
+
+	// should not have changed since its first usage
+	mapEquals(t, ctxWithTim, msa{
+		"one": 1,
+		"agents": map[string]map[string]any{
+			"wit": {
+				"two": 2,
+			},
+			"tim": {
+				"three": 3,
+			},
+		},
+	}, true)
+
 	mapEquals(t, ctxWithBob, msa{
 		"one": 1,
-		"witnessed": map[string]map[string]any{
+		"agents": map[string]map[string]any{
 			"bob": {
 				"four": 4,
 			},

--- a/err.go
+++ b/err.go
@@ -63,10 +63,8 @@ func newErr(
 		file:   file,
 		caller: getCaller(traceDepth + 1),
 		msg:    msg,
-		data: &dataNode{
-			id:     makeNodeID(),
-			values: m,
-		},
+		// no ID needed for err data nodes
+		data: &dataNode{values: m},
 	}
 }
 
@@ -106,10 +104,8 @@ func toStack(
 		file:   file,
 		caller: getCaller(traceDepth + 1),
 		stack:  stack,
-		data: &dataNode{
-			id:     makeNodeID(),
-			values: map[string]any{},
-		},
+		// no ID needed for err dataNodes
+		data: &dataNode{},
 	}
 }
 
@@ -224,7 +220,7 @@ func stackAncestorsOntoSelf(err error) []error {
 // comply with.
 func InErr(err error) *dataNode {
 	if isNilErrIface(err) {
-		return &dataNode{values: map[string]any{}}
+		return &dataNode{}
 	}
 
 	return &dataNode{values: inErr(err)}
@@ -252,7 +248,7 @@ func inErr(err error) map[string]any {
 // data take least priority.
 func (err *Err) Values() *dataNode {
 	if isNilErrIface(err) {
-		return &dataNode{values: map[string]any{}}
+		return &dataNode{}
 	}
 
 	return &dataNode{values: err.values()}
@@ -1026,7 +1022,7 @@ func WithSkipCaller(err error, depth int) *Err {
 // appearance and prefixed by the file and line in which they appeared. This
 // means comments are always added to the error and never clobber each other,
 // regardless of their location.
-func (err *Err) WithComment(msg string, vs ...any) *Err {
+func (err *Err) Comment(msg string, vs ...any) *Err {
 	if isNilErrIface(err) {
 		return nil
 	}
@@ -1052,7 +1048,7 @@ func (err *Err) WithComment(msg string, vs ...any) *Err {
 // appearance and prefixed by the file and line in which they appeared. This
 // means comments are always added to the error and never clobber each other,
 // regardless of their location.
-func WithComment(err error, msg string, vs ...any) *Err {
+func Comment(err error, msg string, vs ...any) *Err {
 	if isNilErrIface(err) {
 		return nil
 	}

--- a/err_test.go
+++ b/err_test.go
@@ -1368,8 +1368,8 @@ func withCommentWrapper(
 ) error {
 	// always add two comments to test that both are saved
 	return clues.
-		WithComment(err, msg, vs...).
-		WithComment(msg+" - repeat", vs...)
+		Comment(err, msg, vs...).
+		Comment(msg+" - repeat", vs...)
 }
 
 func cluesWithCommentWrapper(
@@ -1379,6 +1379,6 @@ func cluesWithCommentWrapper(
 ) error {
 	// always add two comments to test that both are saved
 	return err.
-		WithComment(msg, vs...).
-		WithComment(msg+" - repeat", vs...)
+		Comment(msg, vs...).
+		Comment(msg+" - repeat", vs...)
 }


### PR DESCRIPTION
witnesses add a targeted producer/consumer system to clues that allow downstream producers to relay data back up to upstream consumer contexts.  They're not generally useful, but in certain cases where it becomes difficult to maintain delivery and receipt of clues otherwise they become a sort of necessary evil.