### PR TITLE
adds NoTrace to err interface

### DIFF
--- a/datanode.go
+++ b/datanode.go
@@ -486,12 +486,25 @@ func getCaller(depth int) string {
 	}
 
 	funcPath := runtime.FuncForPC(pc).Name()
+
+	// the funcpath base looks something like this:
+	// prefix.funcName[...].foo.bar
+	// with the [...] only appearing for funcs with generics.
 	base := path.Base(funcPath)
+
+	// so when we split it into parts by '.', we get
+	// [prefix, funcName[, ], foo, bar]
 	parts := strings.Split(base, ".")
 
+	// in certain conditions we'll only get the funcName
+	// itself, without the other parts.  In that case, we
+	// just need to strip the generic portion from the base.
 	if len(parts) < 2 {
 		return strings.ReplaceAll(base, "[...]", "")
 	}
 
+	// in most cases we'll take the 1th index (the func
+	// name) and trim off the bracket that remains from
+	// splitting on a period.
 	return strings.TrimSuffix(parts[1], "[")
 }

--- a/datanode.go
+++ b/datanode.go
@@ -490,8 +490,8 @@ func getCaller(depth int) string {
 	parts := strings.Split(base, ".")
 
 	if len(parts) < 2 {
-		return base
+		return strings.ReplaceAll(base, "[...]", "")
 	}
 
-	return parts[len(parts)-1]
+	return strings.TrimSuffix(parts[1], "[")
 }

--- a/err.go
+++ b/err.go
@@ -25,10 +25,10 @@ type Err struct {
 	// in pre-order traversal.
 	stack []error
 
-	// the func name in which the error was created.
-	// <parentFolder>/<filename>:<line>
+	// the name of the file where the caller func is found.
 	file string
-	// the name of the file owning the caller.
+	// the name of the func where the error (or wrapper) was generated.
+	// <parentFolder>/<filename>:<line>
 	caller string
 
 	// msg is the message for this error.
@@ -1002,6 +1002,20 @@ func WithSkipCaller(err error, depth int) *Err {
 	}
 
 	return e.SkipCaller(depth + 1)
+}
+
+// NoTrace prevents the error from appearing in the trace stack.
+// This is particularly useful for global sentinels that get stacked
+// or wrapped into other error cases.
+func (err *Err) NoTrace() *Err {
+	if isNilErrIface(err) {
+		return nil
+	}
+
+	err.file = ""
+	err.caller = ""
+
+	return err
 }
 
 // ------------------------------------------------------------

--- a/err.go
+++ b/err.go
@@ -28,7 +28,6 @@ type Err struct {
 	// the name of the file where the caller func is found.
 	file string
 	// the name of the func where the error (or wrapper) was generated.
-	// <parentFolder>/<filename>:<line>
 	caller string
 
 	// msg is the message for this error.

--- a/err_test.go
+++ b/err_test.go
@@ -1353,12 +1353,20 @@ func TestLabelCounter_variadic_noCluesInErr(t *testing.T) {
 // helpers
 // ---------------------------------------------------------------------------
 
-func withTraceWrapper(err error, depth int) error {
+func withSkipCaller(err error, depth int) error {
 	return clues.WithSkipCaller(err, depth)
 }
 
-func cluesWithTraceWrapper(err *clues.Err, depth int) error {
+func cluesWithSkipCaller(err *clues.Err, depth int) error {
 	return err.SkipCaller(depth)
+}
+
+func wrapWithFuncWithGeneric[E error](err E) *clues.Err {
+	return clues.Wrap(err, "with-generic")
+}
+
+func withNoTrace(err error) *clues.Err {
+	return clues.Wrap(err, "no-trace").NoTrace()
 }
 
 func withCommentWrapper(


### PR DESCRIPTION
Adds the err.NoTrace() method, which avoids adding any trace information for the specified error.  This is particularly helpful for removing the error trace lines for global sentinels.

Also fixes a bug with the new format of error tracing output where funcs with generics were printing the generics brackets instead of the func name.