### PR TITLE
remove namespace management

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -10,18 +10,8 @@ import (
 
 // Add adds all key-value pairs to the clues.
 func Add(ctx context.Context, kvs ...any) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
-	return setDefaultNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
-}
-
-// AddTo adds all key-value pairs to a namespaced set of clues.
-func AddTo(
-	ctx context.Context,
-	namespace string,
-	kvs ...any,
-) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-	return setNodeInCtx(ctx, namespace, nc.addValues(normalize(kvs...)))
+	nc := nodeFromCtx(ctx)
+	return setNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
 }
 
 // AddMap adds a shallow clone of the map to a namespaced set of clues.
@@ -29,30 +19,14 @@ func AddMap[K comparable, V any](
 	ctx context.Context,
 	m map[K]V,
 ) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 
 	kvs := make([]any, 0, len(m)*2)
 	for k, v := range m {
 		kvs = append(kvs, k, v)
 	}
 
-	return setDefaultNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
-}
-
-// AddMapTo adds a shallow clone of the map to a namespaced set of clues.
-func AddMapTo[K comparable, V any](
-	ctx context.Context,
-	namespace string,
-	m map[K]V,
-) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-
-	kvs := make([]any, 0, len(m)*2)
-	for k, v := range m {
-		kvs = append(kvs, k, v)
-	}
-
-	return setNodeInCtx(ctx, namespace, nc.addValues(normalize(kvs...)))
+	return setNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
 }
 
 // ---------------------------------------------------------------------------
@@ -68,19 +42,8 @@ func AddTrace(
 	ctx context.Context,
 	traceID string,
 ) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
-	return setDefaultNodeInCtx(ctx, nc.trace(traceID))
-}
-
-// AddTraceTo stacks a clues node onto this context within the specified
-// namespace.  Adding a node ensures that a point in code is identified
-// by an ID, which can later be used to correlate and isolate logs to
-// certain trace branches.  AddTraceTo is only needed for layers that don't
-// otherwise call AddTo() or similar functions, since those funcs already
-// attach a new node.
-func AddTraceTo(ctx context.Context, traceID, namespace string) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-	return setNodeInCtx(ctx, namespace, nc.trace(traceID))
+	nc := nodeFromCtx(ctx)
+	return setNodeInCtx(ctx, nc.trace(traceID))
 }
 
 // AddTraceWith stacks a clues node onto this context and uses the provided
@@ -91,7 +54,7 @@ func AddTraceWith(
 	traceID string,
 	kvs ...any,
 ) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 
 	var node *dataNode
 	if len(kvs) > 0 {
@@ -101,28 +64,7 @@ func AddTraceWith(
 		node = nc.trace(traceID)
 	}
 
-	return setDefaultNodeInCtx(ctx, node)
-}
-
-// AddTraceWithTo stacks a clues node onto this context and uses the provided
-// name for the trace id, instead of a randomly generated hash. AddTraceWithTo
-// can be called without additional values if you only want to add a trace marker.
-func AddTraceWithTo(
-	ctx context.Context,
-	traceID, namespace string,
-	kvs ...any,
-) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-
-	var node *dataNode
-	if len(kvs) > 0 {
-		node = nc.addValues(normalize(kvs...))
-		node.id = traceID
-	} else {
-		node = nc.trace(traceID)
-	}
-
-	return setNodeInCtx(ctx, namespace, node)
+	return setNodeInCtx(ctx, node)
 }
 
 // ---------------------------------------------------------------------------
@@ -155,42 +97,10 @@ func AddComment(
 	msg string,
 	vs ...any,
 ) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 	nn := nc.addComment(1, msg, vs...)
 
-	return setDefaultNodeInCtx(ctx, nn)
-}
-
-// AddCommentTo adds a long form comment to the clues in a certain namespace.
-//
-// Comments are special case additions to the context.  They're here to, well,
-// let you add comments!  Why?  Because sometimes it's not sufficient to have a
-// log let you know that a line of code was reached. Even a bunch of clues to
-// describe system state may not be enough.  Sometimes what you need in order
-// to debug the situation is a long-form explanation (you do already add that
-// to your code, don't you?).  Or, even better, a linear history of long-form
-// explanations, each one building on the prior (which you can't easily do in
-// code).
-//
-// Should you transfer all your comments to clues?  Absolutely not.  But in
-// cases where extra explantion is truly important to debugging production,
-// when all you've got are some logs and (maybe if you're lucky) a span trace?
-// Those are the ones you want.
-//
-// Unlike other additions, which are added as top-level key:value pairs to the
-// context, comments are all held as a single array of additions, persisted in
-// order of appearance, and prefixed by the file and line in which they appeared.
-// This means comments are always added to the context and never clobber each
-// other, regardless of their location.  IE: don't add them to a loop.
-func AddCommentTo(
-	ctx context.Context,
-	namespace, msg string,
-	vs ...any,
-) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-	nn := nc.addComment(1, msg, vs...)
-
-	return setNodeInCtx(ctx, namespace, nn)
+	return setNodeInCtx(ctx, nn)
 }
 
 // ---------------------------------------------------------------------------
@@ -214,10 +124,10 @@ func AddAgent(
 	ctx context.Context,
 	name string,
 ) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 	nn := nc.addAgent(name)
 
-	return setDefaultNodeInCtx(ctx, nn)
+	return setNodeInCtx(ctx, nn)
 }
 
 // Relay adds all key-value pairs to the provided agent.  The agent will
@@ -228,7 +138,7 @@ func Relay(
 	agent string,
 	vs ...any,
 ) {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 	ag, ok := nc.agents[agent]
 
 	if !ok {
@@ -248,25 +158,9 @@ func Relay(
 // LabelCounter will use the label as the key for the Add call, and increment
 // the count of that label by one.
 func AddLabelCounter(ctx context.Context, counter Adder) context.Context {
-	nc := nodeFromCtx(ctx, defaultNamespace)
+	nc := nodeFromCtx(ctx)
 	nn := nc.addValues(nil)
 	nn.labelCounter = counter
 
-	return setDefaultNodeInCtx(ctx, nn)
-}
-
-// AddLabelCounterTo embeds an Adder interface into this context. Any already
-// embedded Adder will get replaced.  When adding Labels to a clues.Err the
-// LabelCounter will use the label as the key for the Add call, and increment
-// the count of that label by one.
-func AddLabelCounterTo(
-	ctx context.Context,
-	namespace string,
-	counter Adder,
-) context.Context {
-	nc := nodeFromCtx(ctx, ctxKey(namespace))
-	nn := nc.addValues(nil)
-	nn.labelCounter = counter
-
-	return setNodeInCtx(ctx, namespace, nn)
+	return setNodeInCtx(ctx, nn)
 }

--- a/datanode.go
+++ b/datanode.go
@@ -204,14 +204,7 @@ func (dn *dataNode) lineage(fn func(id string, vs map[string]any)) {
 // TODO: turn return an interface instead of a dataNode, have dataNodes
 // and errors both comply with that wrapper.
 func In(ctx context.Context) *dataNode {
-	return nodeFromCtx(ctx, defaultNamespace)
-}
-
-// InNamespace returns the map of values in the given namespace.
-// TODO: turn return an interface instead of a dataNode, have dataNodes
-// and errors both comply with that wrapper.
-func InNamespace(ctx context.Context, namespace string) *dataNode {
-	return nodeFromCtx(ctx, ctxKey(namespace))
+	return nodeFromCtx(ctx)
 }
 
 // Map flattens the tree of dataNode.values into a map.  Descendant nodes
@@ -401,18 +394,15 @@ func (dn *dataNode) addAgent(name string) *dataNode {
 
 type cluesCtxKey string
 
-const defaultNamespace cluesCtxKey = "default_clues_namespace_key"
+const defaultCtxKey cluesCtxKey = "default_clues_ctx_key"
 
 func ctxKey(namespace string) cluesCtxKey {
 	return cluesCtxKey(namespace)
 }
 
 // nodeFromCtx pulls the datanode within a given namespace out of the context.
-func nodeFromCtx(
-	ctx context.Context,
-	namespace cluesCtxKey,
-) *dataNode {
-	dn := ctx.Value(namespace)
+func nodeFromCtx(ctx context.Context) *dataNode {
+	dn := ctx.Value(defaultCtxKey)
 
 	if dn == nil {
 		return &dataNode{}
@@ -421,23 +411,9 @@ func nodeFromCtx(
 	return dn.(*dataNode)
 }
 
-// setDefaultNodeInCtx adds the context to the dataNode within the given
-// namespace and returns the updated context.
-func setDefaultNodeInCtx(
-	ctx context.Context,
-	dn *dataNode,
-) context.Context {
-	return context.WithValue(ctx, defaultNamespace, dn)
-}
-
-// setNodeInCtx adds the context to the dataNode within the given namespace
-// and returns the updated context.
-func setNodeInCtx(
-	ctx context.Context,
-	namespace string,
-	dn *dataNode,
-) context.Context {
-	return context.WithValue(ctx, ctxKey(namespace), dn)
+// setNodeInCtx embeds the dataNode in the context, and returns the updated context.
+func setNodeInCtx(ctx context.Context, dn *dataNode) context.Context {
+	return context.WithValue(ctx, defaultCtxKey, dn)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
back at the beginning of this package I thought it would be neat to give users a way to isolate different sets of clues into silos.  Afaik it's never been used, and all it does is duplicate the interfaces.  Time for it to go.