### PR TITLE
reposition fmt and secrets

### DIFF
--- a/cecrets/cecrets_test.go
+++ b/cecrets/cecrets_test.go
@@ -1,4 +1,4 @@
-package clues
+package cecrets
 
 import (
 	"fmt"

--- a/clog/settings.go
+++ b/clog/settings.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"github.com/alcionai/clues"
+	"github.com/alcionai/clues/cecrets"
 )
 
 // ---------------------------------------------------
@@ -163,10 +163,10 @@ func GetLogFileOrDefault(useThisFile string) string {
 func setCluesSecretsHash(alg sensitiveInfoHandlingAlgo) {
 	switch alg {
 	case HashSensitiveInfo:
-		clues.SetHasher(clues.DefaultHash())
+		cecrets.SetHasher(cecrets.DefaultHash())
 	case MaskSensitiveInfo:
-		clues.SetHasher(clues.HashCfg{HashAlg: clues.Flatmask})
+		cecrets.SetHasher(cecrets.HashCfg{HashAlg: cecrets.Flatmask})
 	case ShowSensitiveInfoInPlainText:
-		clues.SetHasher(clues.NoHash())
+		cecrets.SetHasher(cecrets.NoHash())
 	}
 }

--- a/clues.go
+++ b/clues.go
@@ -2,6 +2,8 @@ package clues
 
 import (
 	"context"
+
+	"github.com/alcionai/clues/internal/stringify"
 )
 
 // ---------------------------------------------------------------------------
@@ -11,7 +13,7 @@ import (
 // Add adds all key-value pairs to the clues.
 func Add(ctx context.Context, kvs ...any) context.Context {
 	nc := nodeFromCtx(ctx)
-	return setNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
+	return setNodeInCtx(ctx, nc.addValues(stringify.Normalize(kvs...)))
 }
 
 // AddMap adds a shallow clone of the map to a namespaced set of clues.
@@ -26,7 +28,7 @@ func AddMap[K comparable, V any](
 		kvs = append(kvs, k, v)
 	}
 
-	return setNodeInCtx(ctx, nc.addValues(normalize(kvs...)))
+	return setNodeInCtx(ctx, nc.addValues(stringify.Normalize(kvs...)))
 }
 
 // ---------------------------------------------------------------------------
@@ -58,7 +60,7 @@ func AddTraceWith(
 
 	var node *dataNode
 	if len(kvs) > 0 {
-		node = nc.addValues(normalize(kvs...))
+		node = nc.addValues(stringify.Normalize(kvs...))
 		node.id = traceID
 	} else {
 		node = nc.trace(traceID)
@@ -146,5 +148,5 @@ func Relay(
 	}
 
 	// set values, not add.  We don't want agents to own a full clues tree.
-	ag.data.setValues(normalize(vs...))
+	ag.data.setValues(stringify.Normalize(vs...))
 }

--- a/datanode.go
+++ b/datanode.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"reflect"
 	"runtime"
 	"strings"
 
@@ -79,60 +78,6 @@ func (dn *dataNode) spawnDescendant() *dataNode {
 // ---------------------------------------------------------------------------
 // setters
 // ---------------------------------------------------------------------------
-
-// normalize ensures that the variadic of key-value pairs is even in length,
-// and then transforms that slice of values into a map[string]any, where all
-// keys are transformed to string using the marshal() func.
-func normalize(kvs ...any) map[string]any {
-	norm := map[string]any{}
-
-	for i := 0; i < len(kvs); i += 2 {
-		key := marshal(kvs[i], true)
-
-		var value any
-		if i+1 < len(kvs) {
-			value = marshal(kvs[i+1], true)
-		}
-
-		norm[key] = value
-	}
-
-	return norm
-}
-
-// marshal is the central marshalling handler for the entire package.  All
-// stringification of values comes down to this function.  Priority for
-// stringification follows this order:
-// 1. nil -> ""
-// 2. conceal all concealer interfaces
-// 3. flat string values
-// 4. string all stringer interfaces
-// 5. fmt.sprintf the rest
-func marshal(a any, conceal bool) string {
-	if a == nil {
-		return ""
-	}
-
-	// protect against nil pointer values with value-receiver funcs
-	rvo := reflect.ValueOf(a)
-	if rvo.Kind() == reflect.Ptr && rvo.IsNil() {
-		return ""
-	}
-
-	if as, ok := a.(Concealer); conceal && ok {
-		return as.Conceal()
-	}
-
-	if as, ok := a.(string); ok {
-		return as
-	}
-
-	if as, ok := a.(fmt.Stringer); ok {
-		return as.String()
-	}
-
-	return fmt.Sprintf("%+v", a)
-}
 
 // addValues adds all entries in the map to the dataNode's values.
 func (dn *dataNode) addValues(m map[string]any) *dataNode {

--- a/err.go
+++ b/err.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/alcionai/clues/internal/stringify"
 	"golang.org/x/exp/maps"
 )
 
@@ -889,7 +890,7 @@ func (err *Err) With(kvs ...any) *Err {
 	}
 
 	if len(kvs) > 0 {
-		err.data = err.data.addValues(normalize(kvs...))
+		err.data = err.data.addValues(stringify.Normalize(kvs...))
 	}
 
 	return err

--- a/errcore.go
+++ b/errcore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alcionai/clues/internal/stringify"
 	"golang.org/x/exp/maps"
 )
 
@@ -72,7 +73,7 @@ func (ec *ErrCore) stringer(fancy bool) string {
 
 	vsl := []string{}
 	for k, v := range ec.Values {
-		vsl = append(vsl, k+":"+marshal(v, true))
+		vsl = append(vsl, k+":"+stringify.Marshal(v, true))
 	}
 
 	vs := strings.Join(vsl, sep)

--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -1,0 +1,97 @@
+package stringify
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ---------------------------------------------------------------------------
+// types and interfaces
+// ---------------------------------------------------------------------------
+
+// duplicated here from secrets to avoid import cycles.
+// Since this is an internal package, we don't let end users see it.
+type Concealer interface {
+	// Conceal produces an obfuscated representation of the value.
+	Conceal() string
+	// Concealers also need to comply with Format.
+	// Complying with Conceal() alone doesn't guarantee that
+	// the variable won't pass into fmt.Printf("%v") and skip
+	// the whole conceal process.
+	Format(fs fmt.State, verb rune)
+	// PlainStringer is the opposite of conceal.
+	// Useful for if you want to retrieve the raw value of a secret.
+	PlainString() string
+}
+
+// ---------------------------------------------------------------------------
+// funcs
+// ---------------------------------------------------------------------------
+
+// Fmt is an internal func that's currently exposed to get around some
+// import dependencies.  It runs the marshal func for all values provided
+// to it, which will stringify the values according to the clues marshaler
+// and concealer rules.
+func Fmt(vals ...any) []string {
+	resp := make([]string, 0, len(vals))
+
+	for _, v := range vals {
+		resp = append(resp, Marshal(v, false))
+	}
+
+	return resp
+}
+
+// Marshal is the central marshalling handler for the entire package.  All
+// stringification of values comes down to this function.  Priority for
+// stringification follows this order:
+// 1. nil -> ""
+// 2. conceal all concealer interfaces
+// 3. flat string values
+// 4. string all stringer interfaces
+// 5. fmt.sprintf the rest
+func Marshal(a any, shouldConceal bool) string {
+	if a == nil {
+		return ""
+	}
+
+	// protect against nil pointer values with value-receiver funcs
+	rvo := reflect.ValueOf(a)
+	if rvo.Kind() == reflect.Ptr && rvo.IsNil() {
+		return ""
+	}
+
+	if as, ok := a.(Concealer); shouldConceal && ok {
+		return as.Conceal()
+	}
+
+	if as, ok := a.(string); ok {
+		return as
+	}
+
+	if as, ok := a.(fmt.Stringer); ok {
+		return as.String()
+	}
+
+	return fmt.Sprintf("%+v", a)
+}
+
+// Normalize ensures that the variadic of key-value pairs is even in length,
+// and then transforms that slice of values into a map[string]any, where all
+// keys are transformed to string using the marshal() func.
+func Normalize(kvs ...any) map[string]any {
+	norm := map[string]any{}
+
+	for i := 0; i < len(kvs); i += 2 {
+		key := Marshal(kvs[i], true)
+
+		var value any
+		if i+1 < len(kvs) {
+			value = Marshal(kvs[i+1], true)
+		}
+
+		norm[key] = value
+	}
+
+	return norm
+}

--- a/internal/stringify/fmt_test.go
+++ b/internal/stringify/fmt_test.go
@@ -1,0 +1,99 @@
+package stringify
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type aStringer struct {
+	v any
+}
+
+func (a aStringer) String() string {
+	return fmt.Sprintf("%v", a.v)
+}
+
+type notAStringer struct {
+	v any
+}
+
+var _ Concealer = &aConcealer{}
+
+type aConcealer struct {
+	v any
+}
+
+func (a aConcealer) Conceal() string                { return "***" }
+func (a aConcealer) Format(fs fmt.State, verb rune) { io.WriteString(fs, "***") }
+func (a aConcealer) PlainString() string            { return fmt.Sprintf("%v", a.v) }
+
+func TestFmt(t *testing.T) {
+	table := []struct {
+		name   string
+		input  []any
+		expect []string
+	}{
+		{
+			name:   "nil",
+			input:  nil,
+			expect: []string{},
+		},
+		{
+			name:   "any is nil",
+			input:  []any{nil},
+			expect: []string{""},
+		},
+		{
+			name:   "string",
+			input:  []any{"fisher flannigan fitzbog"},
+			expect: []string{"fisher flannigan fitzbog"},
+		},
+		{
+			name:   "number",
+			input:  []any{-1.2345},
+			expect: []string{"-1.2345"},
+		},
+		{
+			name:   "slice",
+			input:  []any{[]int{1, 2, 3, 4, 5}},
+			expect: []string{"[1 2 3 4 5]"},
+		},
+		{
+			name: "map",
+			input: []any{map[string]struct{}{
+				"fisher flannigan fitzbog": struct{}{},
+			}},
+			expect: []string{`map[fisher flannigan fitzbog:{}]`},
+		},
+		{
+			name:   "concealer",
+			input:  []any{aConcealer{"fisher flannigan fitzbog"}},
+			expect: []string{"***"},
+		},
+		{
+			name:   "stringer",
+			input:  []any{aStringer{"I have seen the fnords."}},
+			expect: []string{"I have seen the fnords."},
+		},
+		{
+			name:   "not a stringer",
+			input:  []any{notAStringer{"I have seen the fnords."}},
+			expect: []string{"{v:I have seen the fnords.}"},
+		},
+		{
+			name:   "many values",
+			input:  []any{1, "a", true, aStringer{"smarf"}},
+			expect: []string{"1", "a", "true", "smarf"},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			result := Fmt(test.input...)
+			assert.Equal(t, test.expect, result)
+		})
+	}
+}


### PR DESCRIPTION
In preparation for otel support, I'm repositioning some files and funcs.

1. secrets is moving into `/clues/cecrets`.  This move is for two reasons: 1/ reduce clues api surface area.  2/ isolate "secret" handling from general clues patterns.

2. marshal() and normalize() are moving into `/clues/internal/stringify`.  Marshal will get exposed with a Fmt command for other packages to use (this will be a requirement for otel attribute management).

Outside of the introduction of the Fmt() func, no logical changes should have occurred in this PR.  It's all movement/renaming.