### PR TITLE
remove autogenerated trace id on Add

### DIFF
--- a/datanode.go
+++ b/datanode.go
@@ -86,7 +86,6 @@ func (dn *dataNode) addValues(m map[string]any) *dataNode {
 	}
 
 	spawn := dn.spawnDescendant()
-	spawn.id = makeNodeID()
 	spawn.setValues(m)
 
 	return spawn

--- a/err_fmt_test.go
+++ b/err_fmt_test.go
@@ -1734,11 +1734,10 @@ func TestComment(t *testing.T) {
 
 func TestErrCore_String(t *testing.T) {
 	table := []struct {
-		name             string
-		core             *clues.ErrCore
-		expectS          string
-		expectVPlus      string
-		expectCluesTrace bool
+		name        string
+		core        *clues.ErrCore
+		expectS     string
+		expectVPlus string
 	}{
 		{
 			name:        "nil",
@@ -1753,18 +1752,16 @@ func TestErrCore_String(t *testing.T) {
 				With("key", "value").
 				Label("label").
 				Core(),
-			expectS:          `{"message", [label], {key:value}}`,
-			expectVPlus:      `{msg:"message", labels:[label], values:{key:value}, comments:[]}`,
-			expectCluesTrace: true,
+			expectS:     `{"message", [label], {key:value}}`,
+			expectVPlus: `{msg:"message", labels:[label], values:{key:value}, comments:[]}`,
 		},
 		{
 			name: "message only",
 			core: clues.
 				New("message").
 				Core(),
-			expectS:          `{"message"}`,
-			expectVPlus:      `{msg:"message", labels:[], values:{}, comments:[]}`,
-			expectCluesTrace: false,
+			expectS:     `{"message"}`,
+			expectVPlus: `{msg:"message", labels:[], values:{}, comments:[]}`,
 		},
 		{
 			name: "labels only",
@@ -1772,9 +1769,8 @@ func TestErrCore_String(t *testing.T) {
 				New("").
 				Label("label").
 				Core(),
-			expectS:          `{[label]}`,
-			expectVPlus:      `{msg:"", labels:[label], values:{}, comments:[]}`,
-			expectCluesTrace: false,
+			expectS:     `{[label]}`,
+			expectVPlus: `{msg:"", labels:[label], values:{}, comments:[]}`,
 		},
 		{
 			name: "values only",
@@ -1782,18 +1778,17 @@ func TestErrCore_String(t *testing.T) {
 				New("").
 				With("key", "value").
 				Core(),
-			expectS:          `{{key:value}}`,
-			expectVPlus:      `{msg:"", labels:[], values:{key:value}, comments:[]}`,
-			expectCluesTrace: true,
+			expectS:     `{{key:value}}`,
+			expectVPlus: `{msg:"", labels:[], values:{key:value}, comments:[]}`,
 		},
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
 			tc := test.core
 			if tc != nil {
-				if _, ok := tc.Values["clues_trace"]; ok != test.expectCluesTrace {
+				if _, ok := tc.Values["clues_trace"]; ok {
 					t.Errorf(
-						"expected core values to contain key [clues_trace]\ngot: %+v",
+						"did not expect core values to contain key [clues_trace]\ngot: %+v",
 						tc.Values)
 				}
 				delete(tc.Values, "clues_trace")

--- a/err_test.go
+++ b/err_test.go
@@ -292,8 +292,8 @@ func TestWith(t *testing.T) {
 			for _, kv := range test.with {
 				err = err.With(kv...)
 			}
-			mustEquals(t, test.expect, clues.InErr(err).Map(), true)
-			mustEquals(t, test.expect, err.Values().Map(), true)
+			mustEquals(t, test.expect, clues.InErr(err).Map(), false)
+			mustEquals(t, test.expect, err.Values().Map(), false)
 		})
 	}
 }
@@ -332,8 +332,8 @@ func TestWithMap(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := clues.WithMap(test.initial, test.kv)
 			err = err.WithMap(test.with)
-			mustEquals(t, test.expect, clues.InErr(err).Map(), true)
-			mustEquals(t, test.expect, err.Values().Map(), true)
+			mustEquals(t, test.expect, clues.InErr(err).Map(), false)
+			mustEquals(t, test.expect, err.Values().Map(), false)
 		})
 	}
 }
@@ -375,8 +375,8 @@ func TestWithClues(t *testing.T) {
 			tctx := clues.AddMap(ctx, test.kv)
 			err := clues.WithClues(test.initial, tctx)
 			err = err.WithMap(test.with)
-			mustEquals(t, test.expect, clues.InErr(err).Map(), true)
-			mustEquals(t, test.expect, err.Values().Map(), true)
+			mustEquals(t, test.expect, clues.InErr(err).Map(), false)
+			mustEquals(t, test.expect, err.Values().Map(), false)
 		})
 	}
 }
@@ -426,7 +426,7 @@ func TestValuePriority(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			mustEquals(t, test.expect, clues.InErr(test.err).Map(), true)
+			mustEquals(t, test.expect, clues.InErr(test.err).Map(), false)
 		})
 	}
 }
@@ -681,7 +681,7 @@ func TestErrValues_stacks(t *testing.T) {
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
 			vs := clues.InErr(test.err)
-			mustEquals(t, test.expect, vs.Map(), true)
+			mustEquals(t, test.expect, vs.Map(), false)
 		})
 	}
 }
@@ -690,7 +690,7 @@ func TestImmutableErrors(t *testing.T) {
 	err := clues.New("an error").With("k", "v")
 	check := msa{"k": "v"}
 	pre := clues.InErr(err)
-	mustEquals(t, check, pre.Map(), true)
+	mustEquals(t, check, pre.Map(), false)
 
 	err2 := err.With("k2", "v2")
 	if _, ok := pre.Map()["k2"]; ok {
@@ -1073,7 +1073,7 @@ func TestToCore(t *testing.T) {
 				t.Errorf("expected Msg [%v], got [%v]", test.expectMsg, c.Msg)
 			}
 			mustEquals(t, test.expectLabels, toMSA(c.Labels), false)
-			mustEquals(t, test.expectValues, toMSA(c.Values), true)
+			mustEquals(t, test.expectValues, toMSA(c.Values), false)
 		})
 	}
 }


### PR DESCRIPTION
In preparation for otel compliance, this removes the clues_trace_id autogeneration on every Add call.  In a follow-up PR it will be replaced by AddSpan.