### PR TITLE
remove clog's singleton hook

### DIFF
--- a/clog/builder_test.go
+++ b/clog/builder_test.go
@@ -34,26 +34,6 @@ func (suite *BuilderUnitSuite) TestBuilder() {
 				return Ctx(ctx)
 			},
 		},
-		{
-			name: "singleton",
-			init: func(ctx context.Context) context.Context {
-				return Init(
-					ctx,
-					Settings{}.EnsureDefaults())
-			},
-			bldr: func(ctx context.Context) *builder {
-				return Singleton()
-			},
-		},
-		{
-			name: "singleton, no prior init",
-			init: func(ctx context.Context) context.Context {
-				return ctx
-			},
-			bldr: func(ctx context.Context) *builder {
-				return Singleton()
-			},
-		},
 	}
 
 	for _, test := range table {

--- a/clog/logger.go
+++ b/clog/logger.go
@@ -216,26 +216,6 @@ func CtxErr(ctx context.Context, err error) *builder {
 	return nb
 }
 
-// Singleton is a shorthand for .Ctx(context.Background()).  IE: it'll use the singleton
-// logger directly; building one if necessary.  You should avoid this and use .Ctx or
-// .CtxErr if possible.  Likelihood is that you're somewhere deep in a func chain that
-// doesn't accept a ctx, and you still want to add a quick log; maybe for debugging purposes.
-//
-// That's fine!  Everything should work great.
-//
-// Unless you call this before initialization.  Then it'll panic.  We do want you to init
-// the logger first, else you'll potentially lose these logs due different buffers.
-func Singleton() *builder {
-	if cloggerton == nil {
-		panic(clues.New("clog singleton requires prior initialization"))
-	}
-
-	return &builder{
-		ctx: context.Background(),
-		zsl: cloggerton.zsl,
-	}
-}
-
 // Flush writes out all buffered logs.
 // Probably good to do before shutting down whatever instance
 // had initialized the singleton.


### PR DESCRIPTION
context and deployment management is going to get too complicated to assume we can always reference a global singleton outside of the ctx.