### PR TITLE
adds clues.Inherit for client propagation

### DIFF
--- a/chttp/chttp.go
+++ b/chttp/chttp.go
@@ -1,0 +1,33 @@
+package chttp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/alcionai/clues"
+	"github.com/alcionai/clues/clog"
+	"github.com/alcionai/clues/ctats"
+)
+
+// NewInheritorHTTPMiddleware builds a http middleware which automatically
+// inherits initialized clients from the clues ecosystem and embeds them in
+// the request context.  Since clues prefers context-bound client propagation
+// over global singletons, this behavior is necessary to ensure request contexts
+// maintain scope of initialized values.
+func NewInheritorHTTPMiddleware(
+	ctx context.Context,
+	handler http.Handler,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rctx := r.Context()
+
+		// always assume the request context needs to be clobbered.
+		rctx = clues.Inherit(ctx, rctx, true)
+		rctx = clog.Inherit(ctx, rctx, true)
+		rctx = ctats.Inherit(ctx, rctx, true)
+
+		r = r.WithContext(rctx)
+
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/clog/builder.go
+++ b/clog/builder.go
@@ -34,7 +34,7 @@ type builder struct {
 }
 
 func newBuilder(ctx context.Context) *builder {
-	clgr := fromCtx(ctx)
+	clgr, _ := fromCtx(ctx)
 
 	return &builder{
 		ctx:      ctx,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -248,6 +248,10 @@ func CtxKey(namespace string) CluesCtxKey {
 
 // FromCtx pulls the node within a given namespace out of the context.
 func FromCtx(ctx context.Context) *Node {
+	if ctx == nil {
+		return &Node{}
+	}
+
 	dn := ctx.Value(defaultCtxKey)
 
 	if dn == nil {
@@ -300,7 +304,7 @@ func (dn *Node) Bytes() ([]byte, error) {
 	var serviceName string
 
 	if dn.OTEL != nil {
-		serviceName = dn.OTEL.serviceName
+		serviceName = dn.OTEL.ServiceName
 	}
 
 	core := nodeCore{
@@ -347,7 +351,7 @@ func FromBytes(bs []byte) (*Node, error) {
 
 	if len(core.OTELServiceName) > 0 {
 		node.OTEL = &OTELClient{
-			serviceName: core.OTELServiceName,
+			ServiceName: core.OTELServiceName,
 		}
 	}
 

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -78,7 +78,7 @@ func TestBytes(t *testing.T) {
 			node: func() *Node {
 				return &Node{
 					OTEL: &OTELClient{
-						serviceName: "serviceName",
+						ServiceName: "serviceName",
 					},
 					Values: map[string]any{
 						"fisher":  "flannigan",
@@ -96,7 +96,7 @@ func TestBytes(t *testing.T) {
 				`"comments":[{"Caller":"i am caller","File":"i am file","Message":"i am message"}]}`),
 			expectDeserialized: &Node{
 				OTEL: &OTELClient{
-					serviceName: "serviceName",
+					ServiceName: "serviceName",
 				},
 				Values: map[string]any{
 					"fisher":  "flannigan",

--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -32,7 +32,7 @@ import (
 // ------------------------------------------------------------
 
 type OTELClient struct {
-	serviceName string
+	ServiceName string
 	grpcConn    *grpc.ClientConn
 
 	LoggerProvider *sdkLog.LoggerProvider


### PR DESCRIPTION
Since clues is designed around strict context-bound propagation of values, it runs across some hiccups which other packages tend to solve with global instances.  Namely, patterns where a main func initializes clients (such as otel) but processes requests with a separate context, as is traditional with http servers.

The Inherit(from, to) func gives callers a plug which they can use to propagate clients from their initialized context into individual request-bound contexts, which can be utilized in a http handler middleware.