### PR TITLE
ensure debug logging level

### DIFF
--- a/clog/builder.go
+++ b/clog/builder.go
@@ -112,7 +112,8 @@ func (b builder) log(l logLevel, msg string) {
 	// then write everything to the logger
 	switch l {
 	case LevelDebug:
-		var ok bool
+		// if no label filters are set, always allow debug level logs
+		ok := len(cloggerton.set.OnlyLogDebugIfContainsLabel) == 0
 
 		for _, l := range cloggerton.set.OnlyLogDebugIfContainsLabel {
 			if _, match := b.labels[l]; match {

--- a/clog/logger.go
+++ b/clog/logger.go
@@ -95,6 +95,8 @@ func genLogger(set Settings) *zap.SugaredLogger {
 func zapcoreFallback(set Settings) *zap.Logger {
 	levelFilter := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
 		switch set.Level {
+		case LevelDebug:
+			return true
 		case LevelInfo:
 			return lvl >= zapcore.InfoLevel
 		case LevelError:
@@ -120,6 +122,8 @@ func zapcoreFallback(set Settings) *zap.Logger {
 // converts a given logLevel into the zapcore level enum.
 func setLevel(cfg zap.Config, level logLevel) zap.Config {
 	switch level {
+	case LevelDebug:
+		cfg.Level = zap.NewAtomicLevelAt(zapcore.DebugLevel)
 	case LevelInfo:
 		cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 	case LevelError:


### PR DESCRIPTION
Zap seems to default to info; this ensures default logging levels are respected and utilized.