### PR TITLE
Bump upload-artifact to v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,7 @@ jobs:
     # Upload the original go test output as an artifact for later review.
     - name: Upload test log
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: unit-test-log
         path: testlog/*


### PR DESCRIPTION
v3 is deprecated. Causing failures here https://github.com/alcionai/clues/actions/runs/13572940009/job/37942273806 