### PR TITLE
add better log level control

### DIFF
--- a/clog/otel.go
+++ b/clog/otel.go
@@ -2,7 +2,7 @@ package clog
 
 import "go.opentelemetry.io/otel/log"
 
-func convertLevel(level logLevel) log.Severity {
+func toOTELSeverity(level logLevel) log.Severity {
 	switch level {
 	case LevelDebug:
 		return log.SeverityDebug

--- a/clog/settings.go
+++ b/clog/settings.go
@@ -28,7 +28,7 @@ const (
 func (ll logLevel) includes(lvl logLevel) bool {
 	switch ll {
 	case LevelDebug:
-		return true
+		return lvl != LevelDisabled
 	case LevelInfo:
 		return lvl == LevelError || lvl == LevelInfo
 	case LevelError:

--- a/clog/settings.go
+++ b/clog/settings.go
@@ -23,6 +23,23 @@ const (
 	LevelDisabled logLevel = "disabled"
 )
 
+// includes returns true if the provided log level
+// is of equal or greater importance to the receiver.
+func (ll logLevel) includes(lvl logLevel) bool {
+	switch ll {
+	case LevelDebug:
+		return true
+	case LevelInfo:
+		return lvl == LevelError || lvl == LevelInfo
+	case LevelError:
+		return lvl == LevelError
+	case LevelDisabled:
+		fallthrough
+	default:
+		return false
+	}
+}
+
 type logFormat string
 
 const (

--- a/clog/settings_test.go
+++ b/clog/settings_test.go
@@ -67,7 +67,7 @@ func TestLogLevel_Includes(t *testing.T) {
 		},
 		{
 			name:  "info",
-			input: LevelDebug,
+			input: LevelInfo,
 			allow: []logLevel{
 				LevelInfo,
 				LevelError,
@@ -79,7 +79,7 @@ func TestLogLevel_Includes(t *testing.T) {
 		},
 		{
 			name:  "error",
-			input: LevelDebug,
+			input: LevelError,
 			allow: []logLevel{
 				LevelError,
 			},
@@ -91,7 +91,18 @@ func TestLogLevel_Includes(t *testing.T) {
 		},
 		{
 			name:  "disabled allows nothing",
-			input: LevelDebug,
+			input: LevelDisabled,
+			allow: []logLevel{},
+			notallow: []logLevel{
+				LevelDebug,
+				LevelInfo,
+				LevelError,
+				LevelDisabled,
+			},
+		},
+		{
+			name:  "hacked values allow nothing",
+			input: logLevel("snood"),
 			allow: []logLevel{},
 			notallow: []logLevel{
 				LevelDebug,

--- a/clog/settings_test.go
+++ b/clog/settings_test.go
@@ -45,3 +45,71 @@ func TestSettings_LogToFile(t *testing.T) {
 		})
 	}
 }
+
+func TestLogLevel_Includes(t *testing.T) {
+	table := []struct {
+		name     string
+		input    logLevel
+		allow    []logLevel
+		notallow []logLevel
+	}{
+		{
+			name:  "debug allows everything",
+			input: LevelDebug,
+			allow: []logLevel{
+				LevelDebug,
+				LevelInfo,
+				LevelError,
+			},
+			notallow: []logLevel{
+				LevelDisabled,
+			},
+		},
+		{
+			name:  "info",
+			input: LevelDebug,
+			allow: []logLevel{
+				LevelInfo,
+				LevelError,
+			},
+			notallow: []logLevel{
+				LevelDebug,
+				LevelDisabled,
+			},
+		},
+		{
+			name:  "error",
+			input: LevelDebug,
+			allow: []logLevel{
+				LevelError,
+			},
+			notallow: []logLevel{
+				LevelDebug,
+				LevelInfo,
+				LevelDisabled,
+			},
+		},
+		{
+			name:  "disabled allows nothing",
+			input: LevelDebug,
+			allow: []logLevel{},
+			notallow: []logLevel{
+				LevelDebug,
+				LevelInfo,
+				LevelError,
+				LevelDisabled,
+			},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			for _, allow := range test.allow {
+				assert.True(t, test.input.includes(allow))
+			}
+			for _, not := range test.notallow {
+				assert.False(t, test.input.includes(not))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Current bug: otel is logging at all levels independent of settings.

Fix 1: check otel logger configuration for severity level enablement before logging.

Fix 2: promote log level config check above any given logger, as part of log delivery.