### PR TITLE
go-spew support added for better formatting

### DIFF
--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -81,6 +81,7 @@ func Marshal(a any, shouldConceal bool) string {
 		return fmt.Sprintf("%+v", a)
 	}
 
+	spew.Config.SortKeys = true
 	return spew.Sprintf("%+v", a)
 }
 

--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -3,6 +3,8 @@ package stringify
 import (
 	"fmt"
 	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
 )
 
 // ---------------------------------------------------------------------------
@@ -49,7 +51,8 @@ func Fmt(vals ...any) []string {
 // 2. conceal all concealer interfaces
 // 3. flat string values
 // 4. string all stringer interfaces
-// 5. fmt.sprintf the rest
+// 5. fmt.sprintf all formatter interfaces
+// 6. spew.Sprintf the rest
 func Marshal(a any, shouldConceal bool) string {
 	if a == nil {
 		return ""
@@ -73,7 +76,12 @@ func Marshal(a any, shouldConceal bool) string {
 		return as.String()
 	}
 
-	return fmt.Sprintf("%+v", a)
+	// If value implements fmt.Formatter, then we do not need any additional formatting.
+	if _, ok := a.(fmt.Formatter); ok {
+		return fmt.Sprintf("%+v", a)
+	}
+
+	return spew.Sprintf("%+v", a)
 }
 
 // Normalize ensures that the variadic of key-value pairs is even in length,

--- a/internal/stringify/fmt_test.go
+++ b/internal/stringify/fmt_test.go
@@ -30,7 +30,26 @@ func (a aConcealer) Conceal() string                { return "***" }
 func (a aConcealer) Format(fs fmt.State, verb rune) { io.WriteString(fs, "***") }
 func (a aConcealer) PlainString() string            { return fmt.Sprintf("%v", a.v) }
 
+type testPtrStruct struct {
+	ptrV1 *string
+	inner *testPtrInnerStruct
+}
+
+type testPtrInnerStruct struct {
+	ptrV2 *string
+}
+
 func TestFmt(t *testing.T) {
+	ptrTestString := "ptrString"
+	ptrString := &ptrTestString
+
+	testStruct := &testPtrStruct{
+		ptrV1: ptrString,
+		inner: &testPtrInnerStruct{
+			ptrV2: ptrString,
+		},
+	}
+
 	table := []struct {
 		name   string
 		input  []any
@@ -87,6 +106,16 @@ func TestFmt(t *testing.T) {
 			name:   "many values",
 			input:  []any{1, "a", true, aStringer{"smarf"}},
 			expect: []string{"1", "a", "true", "smarf"},
+		},
+		{
+			name:   "ptr value",
+			input:  []any{ptrString},
+			expect: []string{fmt.Sprintf("<*>(%p)%s", ptrString, ptrTestString)},
+		},
+		{
+			name:   "ptr struct",
+			input:  []any{testStruct},
+			expect: []string{fmt.Sprintf("<*>(%p){ptrV1:<*>(%p)%s inner:<*>(%p){ptrV2:<*>(%p)%s}}", testStruct, ptrString, ptrTestString, testStruct.inner, ptrString, ptrTestString)},
 		},
 	}
 


### PR DESCRIPTION
Built-it golang formatter dereferences pointer only one level deep.
For more complex structures it prints just pointer's address.
This PR introduces support for go-spew library(pretty old, but widely used) which allows to solve such problems.

New exception added for type which implements fmt.Formatter interface. If the type implements formatting that means it knows better how to print it best :) 

go-spew - https://github.com/davecgh/go-spew