### PR TITLE
Map normalization for cluerr.WithMap

### DIFF
--- a/cluerr/clerr.go
+++ b/cluerr/clerr.go
@@ -239,7 +239,7 @@ func (err *Err) WithMap(m map[string]any) *Err {
 	}
 
 	if len(m) > 0 {
-		err.data = err.data.AddValues(m)
+		err.data = err.data.AddValues(stringify.NormalizeMap(m))
 	}
 
 	return err

--- a/clues.go
+++ b/clues.go
@@ -107,13 +107,7 @@ func AddMap[K comparable, V any](
 	m map[K]V,
 ) context.Context {
 	nc := node.FromCtx(ctx)
-
-	kvs := make([]any, 0, len(m)*2)
-	for k, v := range m {
-		kvs = append(kvs, k, v)
-	}
-
-	return node.EmbedInCtx(ctx, nc.AddValues(stringify.Normalize(kvs...)))
+	return node.EmbedInCtx(ctx, nc.AddValues(stringify.NormalizeMap(m)))
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -107,8 +107,10 @@ func Normalize(kvs ...any) map[string]any {
 
 func NormalizeMap[K comparable, V any](m map[K]V) map[string]any {
 	kvs := make([]any, 0, len(m)*2)
+
 	for k, v := range m {
 		kvs = append(kvs, k, v)
 	}
+
 	return Normalize(kvs...)
 }

--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -104,3 +104,11 @@ func Normalize(kvs ...any) map[string]any {
 
 	return norm
 }
+
+func NormalizeMap[K comparable, V any](m map[K]V) map[string]any {
+	kvs := make([]any, 0, len(m)*2)
+	for k, v := range m {
+		kvs = append(kvs, k, v)
+	}
+	return Normalize(kvs...)
+}


### PR DESCRIPTION
Value passed to `cluerr.WithMap` was not normalized. 
This PR introduces new `stringify.NormalizeMap` function which sync normalization implementation for maps with `clues.AddMap `