### PR TITLE
Allow passing in a pre-configured otel resource

### DIFF
--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -105,6 +105,11 @@ type OTELConfig struct {
 	// traces in OTEL. This information will be available in backends on all logs
 	// traces, and metrics that are generated from this source.
 	//
+	// The provided resource should represent the service that's initializing
+	// clues. The resource should encapsulate all parts of the metrics that need
+	// reporting, not just a subset of them (i.e. it represents the "root" of the
+	// information that will be reported to OTEL).
+	//
 	// If not provided, a minimal Resource containing the service name will be
 	// created.
 	Resource *resource.Resource

--- a/otel.go
+++ b/otel.go
@@ -19,6 +19,11 @@ type OTELConfig struct {
 	// traces in OTEL. This information will be available in backends on all logs
 	// traces, and metrics that are generated from this source.
 	//
+	// The provided resource should represent the service that's initializing
+	// clues. The resource should encapsulate all parts of the metrics that need
+	// reporting, not just a subset of them (i.e. it represents the "root" of the
+	// information that will be reported to OTEL).
+	//
 	// If not provided, a minimal Resource containing the service name will be
 	// created.
 	Resource *resource.Resource

--- a/otel.go
+++ b/otel.go
@@ -3,6 +3,8 @@ package clues
 import (
 	"errors"
 
+	"go.opentelemetry.io/otel/sdk/resource"
+
 	"github.com/alcionai/clues/internal/node"
 )
 
@@ -13,6 +15,14 @@ const (
 )
 
 type OTELConfig struct {
+	// Resource contains information about the thing sourcing logs, metrics, and
+	// traces in OTEL. This information will be available in backends on all logs
+	// traces, and metrics that are generated from this source.
+	//
+	// If not provided, a minimal Resource containing the service name will be
+	// created.
+	Resource *resource.Resource
+
 	// specify the endpoint location to use for grpc communication.
 	// If empty, no telemetry exporter will be generated.
 	// ex: localhost:4317
@@ -24,6 +34,7 @@ type OTELConfig struct {
 // clues.OTELConfig is a passthrough to the internal otel config.
 func (oc OTELConfig) toInternalConfig() node.OTELConfig {
 	return node.OTELConfig{
+		Resource:     oc.Resource,
 		GRPCEndpoint: oc.GRPCEndpoint,
 	}
 }


### PR DESCRIPTION
This allows callers to specify a more detailed resource, for example, with detectors for process or OS information.