### PR TITLE
Use a separate config struct to avoid data races

### DIFF
--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -81,8 +81,10 @@ func Marshal(a any, shouldConceal bool) string {
 		return fmt.Sprintf("%+v", a)
 	}
 
-	spew.Config.SortKeys = true
-	return spew.Sprintf("%+v", a)
+	cfg := spew.NewDefaultConfig()
+	cfg.SortKeys = true
+
+	return cfg.Sprintf("%+v", a)
 }
 
 // Normalize ensures that the variadic of key-value pairs is even in length,


### PR DESCRIPTION
The normal `spew.Config` struct is global so `go test -race` flags it as a data race. This creates a new config based on the default values and modifies it, thus avoiding data races.