### PR TITLE
allow noop initiation of stats

### DIFF
--- a/ctats/consts.go
+++ b/ctats/consts.go
@@ -1,0 +1,10 @@
+package ctats
+
+import "github.com/alcionai/clues/cluerr"
+
+var (
+	// errNoNodeInCtx is used to indicate that ctats attempted to retrieve a populated
+	// node out of the provided ctx, but found none.  This means no consuming client
+	// (ie: OTEL.metrics) exists in the context, so no metrics production can occur.
+	errNoNodeInCtx = cluerr.New("no node in ctx - ctats and clues might not be initialized").NoTrace()
+)

--- a/ctats/counter.go
+++ b/ctats/counter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alcionai/clues/cluerr"
 	"github.com/alcionai/clues/internal/node"
 )
 
@@ -80,7 +81,7 @@ func RegisterCounter(
 	// can't do anything if otel hasn't been initialized.
 	nc := node.FromCtx(ctx)
 	if nc.OTEL == nil {
-		return ctx, errors.New("no clues in ctx")
+		return ctx, cluerr.Stack(errNoNodeInCtx)
 	}
 
 	opts := []metric.Float64UpDownCounterOption{}

--- a/ctats/counter_test.go
+++ b/ctats/counter_test.go
@@ -4,21 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alcionai/clues/internal/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCounter(t *testing.T) {
-	noc, err := node.NewOTELClient(
-		context.Background(),
-		t.Name(),
-		node.OTELConfig{})
-	require.NoError(t, err)
-
-	ctx := node.EmbedInCtx(context.Background(), &node.Node{OTEL: noc})
-
-	ctx, err = Initialize(ctx)
+	ctx, err := InitializeNoop(context.Background(), t.Name())
 	require.NoError(t, err)
 
 	ctx, err = RegisterCounter(ctx, "reg.c", "test", "testing counter")

--- a/ctats/counter_test.go
+++ b/ctats/counter_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestCounter(t *testing.T) {
-	ctx, err := InitializeNoop(context.Background(), t.Name())
-	require.NoError(t, err)
+	ctx := InitializeNoop(context.Background(), t.Name())
 
-	ctx, err = RegisterCounter(ctx, "reg.c", "test", "testing counter")
+	ctx, err := RegisterCounter(ctx, "reg.c", "test", "testing counter")
 	require.NoError(t, err)
 
 	metricBus := fromCtx(ctx)

--- a/ctats/ctats.go
+++ b/ctats/ctats.go
@@ -5,9 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"go.opentelemetry.io/otel/metric"
-
-	"github.com/alcionai/clues/cluerr"
 	"github.com/alcionai/clues/internal/node"
 	"github.com/pkg/errors"
 )
@@ -39,9 +36,21 @@ func embedInCtx(ctx context.Context, b *bus) context.Context {
 }
 
 type bus struct {
-	counters   map[string]metric.Float64UpDownCounter
-	gauges     map[string]metric.Float64Gauge
-	histograms map[string]metric.Float64Histogram
+	counters   map[string]adder
+	gauges     map[string]recorder
+	histograms map[string]recorder
+
+	// initializedToNoop is a testing convenience flag that identifies
+	// whether the OTEL client should be configured or not.
+	initializedToNoop bool
+}
+
+func newBus() *bus {
+	return &bus{
+		counters:   map[string]adder{},
+		gauges:     map[string]recorder{},
+		histograms: map[string]recorder{},
+	}
 }
 
 // Initialize ensures that a metrics collector exists in the ctx.
@@ -50,20 +59,16 @@ type bus struct {
 //
 // Multiple calls to Initialize will no-op all after the first.
 func Initialize(ctx context.Context) (context.Context, error) {
+	if fromCtx(ctx) != nil {
+		return ctx, nil
+	}
+
 	nc := node.FromCtx(ctx)
 	if nc == nil || nc.OTEL == nil {
 		return ctx, errors.New("clues.Initialize has not been run on this context")
 	}
 
-	if fromCtx(ctx) != nil {
-		return ctx, nil
-	}
-
-	b := &bus{
-		counters:   map[string]metric.Float64UpDownCounter{},
-		gauges:     map[string]metric.Float64Gauge{},
-		histograms: map[string]metric.Float64Histogram{},
-	}
+	b := newBus()
 
 	return embedInCtx(ctx, b), nil
 }
@@ -72,32 +77,16 @@ func Initialize(ctx context.Context) (context.Context, error) {
 // invoked downstream, but has no expectations of upstream initialization,
 // such as during unit testing.  A noop init runs ctats as normal but without
 // expecting any connection with clients such as OTEL.
-func InitializeNoop(ctx context.Context, svc string) (context.Context, error) {
+func InitializeNoop(ctx context.Context, svc string) context.Context {
 	// if already initialized, do nothing
 	if fromCtx(ctx) != nil {
-		return ctx, nil
+		return ctx
 	}
 
-	nc := node.FromCtx(ctx)
-	if nc == nil {
-		nc = &node.Node{}
-	}
+	b := newBus()
+	b.initializedToNoop = true
 
-	// if otel config already present, we can continue using it.
-	if nc.OTEL == nil {
-		noc, err := node.NewOTELClient(ctx, svc, node.OTELConfig{})
-		if err != nil {
-			return ctx, cluerr.Wrap(err, "generating noop otel client")
-		}
-
-		nc.OTEL = noc
-	}
-
-	ctx = node.EmbedInCtx(ctx, nc)
-
-	ctx, err := Initialize(ctx)
-
-	return ctx, cluerr.Wrap(err, "initializing noop ctats client").OrNil()
+	return embedInCtx(ctx, b)
 }
 
 // Inherit propagates the ctats client from one context to another.  This is particularly

--- a/ctats/ctats_test.go
+++ b/ctats/ctats_test.go
@@ -9,6 +9,12 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+func TestInitializeNoop(t *testing.T) {
+	// should simply work
+	_, err := InitializeNoop(context.Background(), t.Name())
+	require.NoError(t, err)
+}
+
 func TestFormatID(t *testing.T) {
 	table := []struct {
 		name   string

--- a/ctats/ctats_test.go
+++ b/ctats/ctats_test.go
@@ -6,13 +6,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/metric"
 )
 
 func TestInitializeNoop(t *testing.T) {
 	// should simply work
-	_, err := InitializeNoop(context.Background(), t.Name())
-	require.NoError(t, err)
+	ctx := InitializeNoop(context.Background(), t.Name())
+	require.NotNil(t, ctx)
+
+	b := fromCtx(ctx)
+	require.NotNil(t, b)
+	assert.True(t, b.initializedToNoop)
 }
 
 func TestFormatID(t *testing.T) {
@@ -76,11 +79,7 @@ func TestFormatID(t *testing.T) {
 }
 
 func TestInherit(t *testing.T) {
-	stubBus1 := &bus{
-		counters:   map[string]metric.Float64UpDownCounter{},
-		gauges:     map[string]metric.Float64Gauge{},
-		histograms: map[string]metric.Float64Histogram{},
-	}
+	stubBus1 := newBus()
 	stubBus2 := &bus{}
 
 	table := []struct {

--- a/ctats/gauge.go
+++ b/ctats/gauge.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alcionai/clues/cluerr"
 	"github.com/alcionai/clues/internal/node"
 )
 
@@ -42,7 +43,7 @@ func getOrCreateGauge(
 	// make a new one
 	nc := node.FromCtx(ctx)
 	if nc.OTEL == nil {
-		return nil, errors.New("no node in ctx")
+		return nil, cluerr.Stack(errNoNodeInCtx)
 	}
 
 	gauge, err := nc.OTELMeter().Float64Gauge(id)

--- a/ctats/gauge_test.go
+++ b/ctats/gauge_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestGauge(t *testing.T) {
-	ctx, err := InitializeNoop(context.Background(), t.Name())
-	require.NoError(t, err)
+	ctx := InitializeNoop(context.Background(), t.Name())
 
-	ctx, err = RegisterGauge(ctx, "reg.g", "test", "testing gauge")
+	ctx, err := RegisterGauge(ctx, "reg.g", "test", "testing gauge")
 	require.NoError(t, err)
 
 	metricBus := fromCtx(ctx)

--- a/ctats/gauge_test.go
+++ b/ctats/gauge_test.go
@@ -4,21 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alcionai/clues/internal/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGauge(t *testing.T) {
-	noc, err := node.NewOTELClient(
-		context.Background(),
-		t.Name(),
-		node.OTELConfig{})
-	require.NoError(t, err)
-
-	ctx := node.EmbedInCtx(context.Background(), &node.Node{OTEL: noc})
-
-	ctx, err = Initialize(ctx)
+	ctx, err := InitializeNoop(context.Background(), t.Name())
 	require.NoError(t, err)
 
 	ctx, err = RegisterGauge(ctx, "reg.g", "test", "testing gauge")

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alcionai/clues/cluerr"
 	"github.com/alcionai/clues/internal/node"
 )
 
@@ -18,6 +19,7 @@ func histogramFromCtx(
 	id string,
 ) metric.Float64Histogram {
 	b := fromCtx(ctx)
+
 	if b == nil {
 		return nil
 	}
@@ -42,7 +44,7 @@ func getOrCreateHistogram(
 	// make a new one
 	nc := node.FromCtx(ctx)
 	if nc.OTEL == nil {
-		return nil, errors.New("no node in ctx")
+		return nil, cluerr.Stack(errNoNodeInCtx)
 	}
 
 	hist, err := nc.OTELMeter().Float64Histogram(id)

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -9,10 +9,9 @@ import (
 )
 
 func TestHistogram(t *testing.T) {
-	ctx, err := InitializeNoop(context.Background(), t.Name())
-	require.NoError(t, err)
+	ctx := InitializeNoop(context.Background(), t.Name())
 
-	ctx, err = RegisterHistogram(ctx, "reg.h", "test", "testing histogram")
+	ctx, err := RegisterHistogram(ctx, "reg.h", "test", "testing histogram")
 	require.NoError(t, err)
 
 	metricBus := fromCtx(ctx)

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -4,21 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alcionai/clues/internal/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHistogram(t *testing.T) {
-	noc, err := node.NewOTELClient(
-		context.Background(),
-		t.Name(),
-		node.OTELConfig{})
-	require.NoError(t, err)
-
-	ctx := node.EmbedInCtx(context.Background(), &node.Node{OTEL: noc})
-
-	ctx, err = Initialize(ctx)
+	ctx, err := InitializeNoop(context.Background(), t.Name())
 	require.NoError(t, err)
 
 	ctx, err = RegisterHistogram(ctx, "reg.h", "test", "testing histogram")

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/alcionai/clues
 
 go 1.23.2
+
 toolchain go1.24.1
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
@@ -24,7 +26,6 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1 // indirect


### PR DESCRIPTION
Ctats prints a debug log when a request attempts to update the counts without having initialized a node in the ctx.  This can be useful to catch in production deployments, where missing initialization can cripple telemetry gathering.  However, in testing where initialization is not required, the result is extremely chatty and noisesome.

This PR adds a `ctats.InitializeNoop` constructor which allows ctats to run silently in cases where no initialization is expected, such as unit testing.  The result is a much more quiet set of test outputs.