### PR TITLE
Experimental package with function to add otel options to spans

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,8 @@
+The experimental package and subpackages contain features that are undergoing
+development. Features in these packages may undergo breaking changes as we find
+the best solution to the problem at hand.
+
+Moving something out of the experimental tree requires two things:
+* feature APIs becoming (relatively) stable
+* users of said features having enough time to switch to stable APIs outside the
+  experimental subtree prior to deprecation of the experimental API

--- a/experimental/cotel/otel.go
+++ b/experimental/cotel/otel.go
@@ -1,0 +1,29 @@
+package cotel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/alcionai/clues/internal/node"
+	"github.com/alcionai/clues/internal/stringify"
+)
+
+func AddSpanWithOpts(
+	ctx context.Context,
+	name string,
+	kvs []any,
+	opts ...trace.SpanStartOption,
+) context.Context {
+	nc := node.FromCtx(ctx)
+	ctx, spanned := nc.AddSpan(ctx, name, opts...)
+
+	if len(kvs) > 0 {
+		spanned.ID = name
+		spanned = spanned.AddValues(stringify.Normalize(kvs...))
+	} else {
+		spanned = spanned.AppendToTree(name)
+	}
+
+	return node.EmbedInCtx(ctx, spanned)
+}

--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -450,12 +450,13 @@ func (dn *Node) ReceiveTrace(
 func (dn *Node) AddSpan(
 	ctx context.Context,
 	name string,
+	opts ...trace.SpanStartOption,
 ) (context.Context, *Node) {
 	if dn == nil || dn.OTEL == nil {
 		return ctx, dn
 	}
 
-	ctx, span := dn.OTEL.Tracer.Start(ctx, name)
+	ctx, span := dn.OTEL.Tracer.Start(ctx, name, opts...)
 
 	spawn := dn.SpawnDescendant()
 	spawn.Span = span


### PR DESCRIPTION
Create a new experimental package with the ability to pass otel `trace.SpanStartOption`s when making a new span