### PR TITLE
Fix data race when otel isn't initialized

### DIFF
--- a/clues.go
+++ b/clues.go
@@ -155,6 +155,9 @@ func AddSpan(
 	kvs ...any,
 ) context.Context {
 	nc := node.FromCtx(ctx)
+	if nc == nil {
+		return ctx
+	}
 
 	var spanned *node.Node
 

--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -452,7 +452,11 @@ func (dn *Node) AddSpan(
 	name string,
 	opts ...trace.SpanStartOption,
 ) (context.Context, *Node) {
-	if dn == nil || dn.OTEL == nil {
+	if dn == nil {
+		return ctx, dn
+	}
+
+	if dn.OTEL == nil {
 		// Create a new node so that it can have its properties set separately.
 		return ctx, dn.SpawnDescendant()
 	}

--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -453,7 +453,8 @@ func (dn *Node) AddSpan(
 	opts ...trace.SpanStartOption,
 ) (context.Context, *Node) {
 	if dn == nil || dn.OTEL == nil {
-		return ctx, dn
+		// Create a new node so that it can have its properties set separately.
+		return ctx, dn.SpawnDescendant()
 	}
 
 	ctx, span := dn.OTEL.Tracer.Start(ctx, name, opts...)


### PR DESCRIPTION
Always create a new node when a span is requested, even if OTEL isn't initialized. This keeps clues from attempting to modifying properties of the parent node in other calls, which could lead to race conditions if `AddSpan()` is called concurrently or by multiple threads