### PR TITLE
Fix bug with reinitializing OTEL logger

### DIFF
--- a/clog/builder.go
+++ b/clog/builder.go
@@ -38,11 +38,11 @@ type builder struct {
 
 func newBuilder(ctx context.Context) *builder {
 	clgr, _ := fromCtx(ctx)
-	nd := clues.In(ctx)
+	ctxNode := clues.In(ctx)
 
 	return &builder{
 		ctx:      ctx,
-		otel:     nd.OTELLogger(),
+		otel:     ctxNode.OTELLogger(),
 		zsl:      clgr.zsl,
 		with:     map[any]any{},
 		labels:   map[string]struct{}{},

--- a/clog/builder.go
+++ b/clog/builder.go
@@ -38,10 +38,11 @@ type builder struct {
 
 func newBuilder(ctx context.Context) *builder {
 	clgr, _ := fromCtx(ctx)
+	node := clues.In(ctx)
 
 	return &builder{
 		ctx:      ctx,
-		otel:     clgr.otel,
+		otel:     node.OTELLogger(),
 		zsl:      clgr.zsl,
 		with:     map[any]any{},
 		labels:   map[string]struct{}{},

--- a/clog/builder.go
+++ b/clog/builder.go
@@ -38,11 +38,11 @@ type builder struct {
 
 func newBuilder(ctx context.Context) *builder {
 	clgr, _ := fromCtx(ctx)
-	node := clues.In(ctx)
+	nd := clues.In(ctx)
 
 	return &builder{
 		ctx:      ctx,
-		otel:     node.OTELLogger(),
+		otel:     nd.OTELLogger(),
 		zsl:      clgr.zsl,
 		with:     map[any]any{},
 		labels:   map[string]struct{}{},

--- a/clog/logger.go
+++ b/clog/logger.go
@@ -20,6 +20,10 @@ var (
 )
 
 type clogger struct {
+	// zsl is the underlying zap logger that was configured for the system. We
+	// don't hold a reference to OTEL even though it may have been configured
+	// because OTEL can be closed and re-opened. If that happens, we want to make
+	// sure logs are sent to the new OTEL instance instead of turning into noops.
 	zsl *zap.SugaredLogger
 	set Settings
 }

--- a/clog/logger.go
+++ b/clog/logger.go
@@ -133,7 +133,7 @@ func setLevel(cfg zap.Config, level logLevel) zap.Config {
 
 // singleton is the constructor and getter in one. Since we manage a global
 // singleton for each instance, we only ever want one alive at any given time.
-func singleton(ctx context.Context, set Settings) *clogger {
+func singleton(set Settings) *clogger {
 	singleMu.Lock()
 	defer singleMu.Unlock()
 
@@ -169,7 +169,7 @@ const ctxKey loggingKey = "clog_logger"
 // with the default values.  If you need to configure your logs,
 // make sure to embed this first.
 func Init(ctx context.Context, set Settings) context.Context {
-	clogged := singleton(ctx, set)
+	clogged := singleton(set)
 	clogged.zsl.Debugw("seeding logger", "logger_settings", set)
 
 	return plantLoggerInCtx(ctx, clogged)
@@ -199,7 +199,7 @@ func plantLoggerInCtx(
 // ctx, it returns the global singleton.
 func fromCtx(ctx context.Context) (*clogger, bool) {
 	if ctx == nil {
-		return singleton(ctx, Settings{}.EnsureDefaults()), false
+		return singleton(Settings{}.EnsureDefaults()), false
 	}
 
 	found := true
@@ -208,7 +208,7 @@ func fromCtx(ctx context.Context) (*clogger, bool) {
 	// if l is still nil, we need to grab the global singleton or construct a singleton.
 	if l == nil {
 		found = false
-		l = singleton(ctx, Settings{}.EnsureDefaults())
+		l = singleton(Settings{}.EnsureDefaults())
 	}
 
 	return l.(*clogger), found

--- a/clog/logger.go
+++ b/clog/logger.go
@@ -7,11 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/alcionai/clues"
 )
 
 // Yes, we just hijack zap for our logging needs here.
@@ -23,9 +20,8 @@ var (
 )
 
 type clogger struct {
-	otel log.Logger
-	zsl  *zap.SugaredLogger
-	set  Settings
+	zsl *zap.SugaredLogger
+	set Settings
 }
 
 // ---------------------------------------------------------------------------
@@ -153,12 +149,6 @@ func singleton(ctx context.Context, set Settings) *clogger {
 	cloggerton = &clogger{
 		zsl: zsl,
 		set: set,
-	}
-
-	node := clues.In(ctx)
-
-	if node.OTELLogger() != nil {
-		cloggerton.otel = node.OTELLogger()
 	}
 
 	return cloggerton


### PR DESCRIPTION
Always source the OTEL logger from the context instead of the logger singleton. This is important since the OTEL logger can have a different lifetime than the zap logger singleton. Therefore, sourcing the OTEL logger from the context ensures that if the OTEL logger is closed and re-initialized elsewhere logs continue to be sent to the configured OTEL collector.