### PR TITLE
introduce AddToOTELHTTPLabeler

### DIFF
--- a/clog/try.go
+++ b/clog/try.go
@@ -67,7 +67,10 @@ func (tb *tryBuilder) With(kvs ...any) *tryBuilder {
 
 	tb.ctx = node.EmbedInCtx(
 		tb.ctx,
-		nc.AddValues(stringify.Normalize(kvs...)),
+		nc.AddValues(
+			tb.ctx,
+			stringify.Normalize(kvs...),
+		),
 	)
 
 	tb.logBuilder.With(kvs...)

--- a/cluerr/clerr.go
+++ b/cluerr/clerr.go
@@ -226,7 +226,7 @@ func (err *Err) With(kvs ...any) *Err {
 	}
 
 	if len(kvs) > 0 {
-		err.data = err.data.AddValues(stringify.Normalize(kvs...))
+		err.data = err.data.AddValues(context.Background(), stringify.Normalize(kvs...))
 	}
 
 	return err
@@ -239,7 +239,7 @@ func (err *Err) WithMap(m map[string]any) *Err {
 	}
 
 	if len(m) > 0 {
-		err.data = err.data.AddValues(stringify.NormalizeMap(m))
+		err.data = err.data.AddValues(context.Background(), stringify.NormalizeMap(m))
 	}
 
 	return err

--- a/clues.go
+++ b/clues.go
@@ -99,7 +99,7 @@ func In(ctx context.Context) *node.Node {
 // Add adds all key-value pairs to the clues.
 func Add(ctx context.Context, kvs ...any) context.Context {
 	nc := node.FromCtx(ctx)
-	return node.EmbedInCtx(ctx, nc.AddValues(stringify.Normalize(kvs...)))
+	return node.EmbedInCtx(ctx, nc.AddValues(ctx, stringify.Normalize(kvs...)))
 }
 
 // AddMap adds a shallow clone of the map to a namespaced set of clues.
@@ -108,7 +108,7 @@ func AddMap[K comparable, V any](
 	m map[K]V,
 ) context.Context {
 	nc := node.FromCtx(ctx)
-	return node.EmbedInCtx(ctx, nc.AddValues(stringify.NormalizeMap(m)))
+	return node.EmbedInCtx(ctx, nc.AddValues(ctx, stringify.NormalizeMap(m)))
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +164,7 @@ func AddSpan(
 	if len(kvs) > 0 {
 		ctx, spanned = nc.AddSpan(ctx, name)
 		spanned.ID = name
-		spanned = spanned.AddValues(stringify.Normalize(kvs...))
+		spanned = spanned.AddValues(ctx, stringify.Normalize(kvs...))
 	} else {
 		ctx, spanned = nc.AddSpan(ctx, name)
 		spanned = spanned.AppendToTree(name)

--- a/clutel/clutel.go
+++ b/clutel/clutel.go
@@ -1,0 +1,34 @@
+package clutel
+
+import (
+	"context"
+
+	"github.com/alcionai/clues/internal/node"
+	"github.com/alcionai/clues/internal/stringify"
+)
+
+// AddToOTELHTTPLabeler adds key-value pairs to both the current
+// context and the OpenTelemetry HTTP labeler, but not the current
+// span.  The labeler will hold onto these values until the next
+// request arrives at the otelhttp transport, at which point they
+// are added to the span for that transport.
+//
+// The best use case for this func is to wait until the last wrapper
+// used to handle a http.Request.Do() call.  Add your http request
+// details (url, payload metadata, etc) at that point so that they
+// appear both in the next span, and in any errors you handle from
+// that wrapper.
+func AddToOTELHTTPLabeler(
+	ctx context.Context,
+	name string,
+	kvs ...any,
+) context.Context {
+	nc := node.FromCtx(ctx)
+	ctx, labeler := node.OTELHTTPLabelerFromCtx(ctx)
+
+	return node.EmbedInCtx(ctx, nc.AddValues(
+		ctx,
+		stringify.Normalize(kvs...),
+		node.AddToOTELHTTPLabeler(labeler),
+	))
+}

--- a/experimental/cotel/otel.go
+++ b/experimental/cotel/otel.go
@@ -20,7 +20,7 @@ func AddSpanWithOpts(
 
 	if len(kvs) > 0 {
 		spanned.ID = name
-		spanned = spanned.AddValues(stringify.Normalize(kvs...))
+		spanned = spanned.AddValues(ctx, stringify.Normalize(kvs...))
 	} else {
 		spanned = spanned.AppendToTree(name)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/puzpuzpuz/xsync/v4 v4.1.0
 	github.com/stretchr/testify v1.10.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0
 	go.opentelemetry.io/contrib/processors/baggagecopy v0.10.0
 	go.opentelemetry.io/otel v1.37.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.13.0
@@ -26,6 +27,7 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -31,6 +33,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 h1:Hf9xI/XLML9ElpiHVDNwvqI0hIFlzV8dgIr35kV1kRU=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0/go.mod h1:NfchwuyNoMcZ5MLHwPrODwUF1HWCXWrL31s8gSAdIKY=
 go.opentelemetry.io/contrib/processors/baggagecopy v0.10.0 h1:funq8vLW1lx+q/zalPQ8/aw0/DnjJZV/t851WgnFzD8=
 go.opentelemetry.io/contrib/processors/baggagecopy v0.10.0/go.mod h1:296HlBf5jKjdYXOt037ysssFw/GaqArnz3P1I2NbDH4=
 go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=


### PR DESCRIPTION
1. Intruduces the `clutel` package, which will be the owner of all future otel-based funcs.
2. Extends the node attribute setter with variadic options to enable control over things like whether attributes should get added to the span.
3. Addts the `AddToOTELHTTPLabeler` function, which allows adding attributes to the upcoming span of an HTTP request.