### PR TITLE
add baggage additions to clutel

### DIFF
--- a/internal/stringify/fmt.go
+++ b/internal/stringify/fmt.go
@@ -107,6 +107,24 @@ func Normalize(kvs ...any) map[string]any {
 	return norm
 }
 
+// Stringalize is a convenience function that does the exact same thing as
+// Normalize, but it casts all values to string instead of any.
+func Stringalize(kvs ...any) map[string]string {
+	norm := Normalize(kvs...)
+	stringy := make(map[string]string, len(norm))
+
+	for k, v := range norm {
+		sv, ok := v.(string)
+		if !ok {
+			sv = Marshal(v, false)
+		}
+
+		stringy[k] = sv
+	}
+
+	return stringy
+}
+
 func NormalizeMap[K comparable, V any](m map[K]V) map[string]any {
 	kvs := make([]any, 0, len(m)*2)
 

--- a/internal/stringify/fmt_test.go
+++ b/internal/stringify/fmt_test.go
@@ -223,6 +223,80 @@ func TestNormalize(t *testing.T) {
 	}
 }
 
+func TestStringalize(t *testing.T) {
+	table := []struct {
+		name   string
+		input  []any
+		expect map[string]string
+	}{
+		{
+			name:   "nil",
+			input:  nil,
+			expect: map[string]string{},
+		},
+		{
+			name:   "any is nil",
+			input:  []any{nil},
+			expect: map[string]string{"": ""},
+		},
+		{
+			name:   "string",
+			input:  []any{"fisher flannigan", "fitzbog"},
+			expect: map[string]string{"fisher flannigan": "fitzbog"},
+		},
+		{
+			name:   "number",
+			input:  []any{-1.2345, 54321},
+			expect: map[string]string{"-1.2345": "54321"},
+		},
+		{
+			name:   "slice",
+			input:  []any{[]int{1, 2, 3, 4, 5}, []string{"a", "b"}},
+			expect: map[string]string{"[1 2 3 4 5]": "[a b]"},
+		},
+		{
+			name: "map",
+			input: []any{
+				map[string]struct{}{
+					"fisher flannigan fitzbog": {},
+				},
+				map[int]int{},
+			},
+			expect: map[string]string{`map[fisher flannigan fitzbog:{}]`: "map[]"},
+		},
+		{
+			name:   "concealer",
+			input:  []any{aConcealer{"fisher flannigan fitzbog"}},
+			expect: map[string]string{"***": ""},
+		},
+		{
+			name:   "stringer",
+			input:  []any{aStringer{"I have seen the fnords."}},
+			expect: map[string]string{"I have seen the fnords.": ""},
+		},
+		{
+			name:   "not a stringer",
+			input:  []any{notAStringer{"I have seen the fnords."}},
+			expect: map[string]string{"{v:I have seen the fnords.}": ""},
+		},
+		{
+			name:  "many values",
+			input: []any{1, "a", true, aStringer{"smarf"}},
+			expect: map[string]string{
+				"1":    "a",
+				"true": "smarf",
+			},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			result := Stringalize(test.input...)
+			assert.Equal(t, test.expect, result)
+		})
+	}
+}
+
 func TestNormalizeMap(t *testing.T) {
 	ptrTestString := "ptrString"
 	ptrString := &ptrTestString

--- a/internal/tester/tester.go
+++ b/internal/tester/tester.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/alcionai/clues/internal/node"
+	"github.com/alcionai/clues/internal/stringify"
 )
 
 func MapEquals(
@@ -132,7 +133,7 @@ func (s SA) equals(t *testing.T, other []any) {
 		var found bool
 
 		for _, o := range other {
-			if v == o {
+			if stringify.Marshal(v, false) == stringify.Marshal(o, false) {
 				found = true
 				break
 			}
@@ -147,7 +148,7 @@ func (s SA) equals(t *testing.T, other []any) {
 		var found bool
 
 		for _, v := range s {
-			if v == o {
+			if stringify.Marshal(v, false) == stringify.Marshal(o, false) {
 				found = true
 				break
 			}


### PR DESCRIPTION
    Adds two functions to clutel: `AddBaggage`, which handles standard k-v
    pair additions for baggage.  And `AddBaggageProps` which allows
    declaring baggage as both member and property values.

    Unlike the otel standard for baggage additions, this function extends
    the current baggage rather than clobbering it.