### PR TITLE
add clutel span error funcs

### DIFF
--- a/clog/try.go
+++ b/clog/try.go
@@ -3,9 +3,6 @@ package clog
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/alcionai/clues/internal/node"
 	"github.com/alcionai/clues/internal/stringify"
 )
@@ -147,15 +144,7 @@ func (tb *tryBuilder) Catch(handler catchHandler) {
 		Comment(msg)
 
 	if tb.setSpanErr {
-		span := trace.SpanFromContext(tb.ctx)
-
-		if span != nil {
-			span.SetStatus(codes.Error, msg)
-			span.RecordError(
-				r.(error),
-				trace.WithStackTrace(true),
-			)
-		}
+		node.SetSpanError(tb.ctx, r.(error), msg)
 	}
 
 	if handler != nil {

--- a/cluerr/comments.go
+++ b/cluerr/comments.go
@@ -1,6 +1,9 @@
 package cluerr
 
-import "github.com/alcionai/clues/internal/node"
+import (
+	"github.com/alcionai/clues/internal/errs"
+	"github.com/alcionai/clues/internal/node"
+)
 
 // ------------------------------------------------------------
 // comments
@@ -13,7 +16,7 @@ func (err *Err) Comments() node.CommentHistory {
 
 // Comments retrieves all comments in the error.
 func Comments(err error) node.CommentHistory {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return node.CommentHistory{}
 	}
 
@@ -47,7 +50,7 @@ func Comments(err error) node.CommentHistory {
 // means comments are always added to the error and never clobber each other,
 // regardless of their location.
 func (err *Err) Comment(msg string, vs ...any) *Err {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return nil
 	}
 

--- a/cluerr/errcore.go
+++ b/cluerr/errcore.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alcionai/clues/internal/errs"
 	"github.com/alcionai/clues/internal/node"
 	"github.com/alcionai/clues/internal/stringify"
 )
@@ -27,7 +28,7 @@ type ErrCore struct {
 // hierarchical storage of errors and data nodes into a flat, easily consumed
 // set of properties.
 func (err *Err) Core() *ErrCore {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return nil
 	}
 
@@ -46,7 +47,7 @@ func (err *Err) Core() *ErrCore {
 // hierarchical storage of errors and data nodes into a flat, easily consumed
 // set of properties.
 func ToCore(err error) *ErrCore {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return nil
 	}
 

--- a/cluerr/labels.go
+++ b/cluerr/labels.go
@@ -1,13 +1,17 @@
 package cluerr
 
-import "maps"
+import (
+	"maps"
+
+	"github.com/alcionai/clues/internal/errs"
+)
 
 // ------------------------------------------------------------
 // labels
 // ------------------------------------------------------------
 
 func (err *Err) HasLabel(label string) bool {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return false
 	}
 
@@ -22,7 +26,7 @@ func (err *Err) HasLabel(label string) bool {
 }
 
 func HasLabel(err error, label string) bool {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return false
 	}
 
@@ -34,7 +38,7 @@ func HasLabel(err error, label string) bool {
 }
 
 func (err *Err) Label(labels ...string) *Err {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return nil
 	}
 
@@ -54,7 +58,7 @@ func Label(err error, label string) *Err {
 }
 
 func (err *Err) Labels() map[string]struct{} {
-	if isNilErrIface(err) {
+	if errs.IsNilIface(err) {
 		return map[string]struct{}{}
 	}
 

--- a/clutel/clutel_test.go
+++ b/clutel/clutel_test.go
@@ -441,3 +441,137 @@ func TestNewBaggageProps(t *testing.T) {
 		})
 	}
 }
+
+func TestEndSpanWithErrors(t *testing.T) {
+	table := []struct {
+		name string
+		err  error
+	}{
+		{
+			"an_err",
+			assert.AnError,
+		},
+		{
+			"nil",
+			nil,
+		},
+	}
+	for _, test := range table {
+		for _, init := range []bool{true, false} {
+			tname := fmt.Sprintf("%s-%v", test.name, init)
+
+			t.Run(tname, func(t *testing.T) {
+				ctx := t.Context()
+
+				if init {
+					ocfg := clues.OTELConfig{GRPCEndpoint: "localhost:4317"}
+
+					ictx, err := clues.InitializeOTEL(ctx, test.name, ocfg)
+					require.NoError(t, err, "initializing otel")
+
+					if err != nil {
+						return
+					}
+
+					ctx = ictx
+				}
+
+				ctx = clutel.NewSpan().
+					WithOpts(
+						trace.WithSpanKind(trace.SpanKindInternal),
+						trace.WithAttributes(attribute.String("clues_trace", test.name)),
+					).
+					Start(ctx, test.name)
+
+				// not testing much here; mostly catching panics and asserting usage.
+				defer clutel.EndSpanWithError(ctx, test.err)
+			})
+		}
+	}
+}
+
+func TestSetSpanError(t *testing.T) {
+	table := []struct {
+		name string
+		err  error
+	}{
+		{
+			"an_err",
+			assert.AnError,
+		},
+		{
+			"nil",
+			nil,
+		},
+	}
+	for _, test := range table {
+		for _, init := range []bool{true, false} {
+			tname := fmt.Sprintf("%s-%v", test.name, init)
+
+			t.Run(tname, func(t *testing.T) {
+				ctx := t.Context()
+
+				if init {
+					ocfg := clues.OTELConfig{GRPCEndpoint: "localhost:4317"}
+
+					ictx, err := clues.InitializeOTEL(ctx, test.name, ocfg)
+					require.NoError(t, err, "initializing otel")
+
+					if err != nil {
+						return
+					}
+
+					ctx = ictx
+				}
+
+				ctx = clutel.NewSpan().
+					Start(ctx, test.name)
+
+				clutel.SetSpanError(ctx, test.err)
+			})
+		}
+	}
+}
+
+func TestSetSpanErrorM(t *testing.T) {
+	table := []struct {
+		name string
+		msg  string
+	}{
+		{
+			"an_err",
+			assert.AnError.Error(),
+		},
+		{
+			"empty_message",
+			"",
+		},
+	}
+	for _, test := range table {
+		for _, init := range []bool{true, false} {
+			tname := fmt.Sprintf("%s-%v", test.name, init)
+
+			t.Run(tname, func(t *testing.T) {
+				ctx := t.Context()
+
+				if init {
+					ocfg := clues.OTELConfig{GRPCEndpoint: "localhost:4317"}
+
+					ictx, err := clues.InitializeOTEL(ctx, test.name, ocfg)
+					require.NoError(t, err, "initializing otel")
+
+					if err != nil {
+						return
+					}
+
+					ctx = ictx
+				}
+
+				ctx = clutel.NewSpan().
+					Start(ctx, test.name)
+
+				clutel.SetSpanErrorM(ctx, test.msg)
+			})
+		}
+	}
+}

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,20 @@
+package errs
+
+import "reflect"
+
+// ------------------------------------------------------------
+// helpers
+// ------------------------------------------------------------
+
+// IsNilIfac returns true if the error is nil, or if it is a
+// non-nil interface containing a nil value.
+func IsNilIface(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	val := reflect.ValueOf(err)
+
+	return (val.Kind() == reflect.Pointer ||
+		val.Kind() == reflect.Interface) && val.IsNil()
+}


### PR DESCRIPTION
One of the most common ways of interfacing with spans, aside from creating and closing them, is setting their status to a failure state. It's a little bit bulky in raw usage, so here's some quick helpers for it.

Along the way I wanted to begin peicemealing little bits of the error handing to an internal package, and this was an opportunity to start with that by relocating the nil iface checker.  It isn't an error specific check at heart, but since we only use it for errors, it still lives there.