### PR TITLE
add error comments to logs

### DIFF
--- a/clog/builder.go
+++ b/clog/builder.go
@@ -92,6 +92,12 @@ func (b builder) log(l logLevel, msg string) {
 		if len(labels) > 0 {
 			cv["error_labels"] = cluerr.Labels(b.err)
 		}
+
+		errComments := cluerr.Comments(b.err)
+
+		if len(errComments) > 0 {
+			cv["error_comments"] = errComments
+		}
 	}
 
 	// attach the clog labels and comments


### PR DESCRIPTION
If errors have a comment, they should be added to the logs alongside the labels and attrs.