### PR TITLE
feat(clutel): add WithTraceSampler option to OTELConfig

### DIFF
--- a/clutel/clutel_test.go
+++ b/clutel/clutel_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/baggage"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/alcionai/clues/cluerr"
@@ -573,6 +574,50 @@ func TestSetSpanErrorM(t *testing.T) {
 				clutel.SetSpanErrorM(ctx, test.msg)
 			})
 		}
+	}
+}
+
+func TestWithTraceSampler(t *testing.T) {
+	table := []struct {
+		name            string
+		sampler         sdkTrace.Sampler
+		expectRecording bool
+	}{
+		{
+			name:            "default_always_samples",
+			sampler:         nil,
+			expectRecording: true,
+		},
+		{
+			name:            "explicit_always_sample",
+			sampler:         sdkTrace.AlwaysSample(),
+			expectRecording: true,
+		},
+		{
+			name:            "never_sample",
+			sampler:         sdkTrace.NeverSample(),
+			expectRecording: false,
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			var cfg clutel.OTELConfig
+			if test.sampler != nil {
+				cfg = clutel.NewConfig(nil, "localhost:4317", clutel.WithTraceSampler(test.sampler))
+			} else {
+				cfg = clutel.NewConfig(nil, "localhost:4317")
+			}
+
+			ctx, err := clutel.Init(t.Context(), "test", cfg)
+			require.NoError(t, err)
+
+			ctx = clutel.StartSpan(ctx, "test-span")
+			defer clutel.EndSpan(ctx)
+
+			span := clutel.GetSpan(ctx)
+			assert.Equal(t, test.expectRecording, span.IsRecording())
+		})
 	}
 }
 

--- a/clutel/config.go
+++ b/clutel/config.go
@@ -48,7 +48,7 @@ type OTELConfig struct {
 	meterExporterOpts []otlpmetricgrpc.Option
 
 	// sampler controls trace sampling. Defaults to AlwaysSample when nil.
-	sampler sdkTrace.Sampler
+	traceSampler sdkTrace.Sampler
 }
 
 // NewConfig creates a new OTELConfig with the given parameters and options.  All
@@ -81,9 +81,9 @@ func (oc *OTELConfig) applyOptions(opts ...Option) {
 // WithTraceSampler sets the trace sampler used by the TracerProvider.
 // Defaults to AlwaysSample when not specified.
 // Use sdktrace.ParentBased(sdktrace.TraceIDRatioBased(rate)) for probabilistic sampling.
-func WithTraceSampler(sampler sdkTrace.Sampler) Option {
+func WithTraceSampler(traceSampler sdkTrace.Sampler) Option {
 	return func(o *OTELConfig) {
-		o.sampler = sampler
+		o.traceSampler = traceSampler
 	}
 }
 
@@ -130,6 +130,6 @@ func (oc OTELConfig) toInternalConfig() node.OTELConfig {
 		GRPCEndpoint:      oc.GRPCEndpoint,
 		Filter:            oc.Filter,
 		MeterExporterOpts: oc.meterExporterOpts,
-		Sampler:           oc.sampler,
+		Sampler:           oc.traceSampler,
 	}
 }

--- a/clutel/config.go
+++ b/clutel/config.go
@@ -7,8 +7,8 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	sdkMetric "go.opentelemetry.io/otel/sdk/metric"
-	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/alcionai/clues/internal/node"
 )

--- a/clutel/config.go
+++ b/clutel/config.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	sdkMetric "go.opentelemetry.io/otel/sdk/metric"
+	sdkTrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/resource"
 
 	"github.com/alcionai/clues/internal/node"
@@ -45,6 +46,9 @@ type OTELConfig struct {
 
 	// meterExporterOpts contains options to apply to the meter provider's default reader.
 	meterExporterOpts []otlpmetricgrpc.Option
+
+	// sampler controls trace sampling. Defaults to AlwaysSample when nil.
+	sampler sdkTrace.Sampler
 }
 
 // NewConfig creates a new OTELConfig with the given parameters and options.  All
@@ -53,7 +57,7 @@ type OTELConfig struct {
 func NewConfig(
 	rsrc *resource.Resource,
 	grpcEndpoint string,
-	opts ...option,
+	opts ...Option,
 ) OTELConfig {
 	oc := &OTELConfig{
 		Resource:     rsrc,
@@ -65,18 +69,28 @@ func NewConfig(
 	return *oc
 }
 
-type option func(o *OTELConfig)
+// Option configures an OTELConfig.
+type Option func(o *OTELConfig)
 
-func (oc *OTELConfig) applyOptions(opts ...option) {
+func (oc *OTELConfig) applyOptions(opts ...Option) {
 	for _, o := range opts {
 		o(oc)
+	}
+}
+
+// WithTraceSampler sets the trace sampler used by the TracerProvider.
+// Defaults to AlwaysSample when not specified.
+// Use sdktrace.ParentBased(sdktrace.TraceIDRatioBased(rate)) for probabilistic sampling.
+func WithTraceSampler(sampler sdkTrace.Sampler) Option {
+	return func(o *OTELConfig) {
+		o.sampler = sampler
 	}
 }
 
 // WithDeltaTemporalityMeter sets the OTLP metric exporter to use delta temporality
 // for the MeterProvider instrument.  This only affects Sum (ie: OTELCounter) type
 // metric aggregations.
-func WithDeltaTemporalityMeter() option {
+func WithDeltaTemporalityMeter() Option {
 	return func(o *OTELConfig) {
 		o.meterExporterOpts = append(
 			o.meterExporterOpts,
@@ -91,7 +105,7 @@ var BlockAllBaggage baggagecopy.Filter = func(baggage.Member) bool { return fals
 
 // WithBlockAllBaggage sets the OTELConfig to block copying all memebers of baggage to
 // a span.
-func WithBlockAllBaggage() option {
+func WithBlockAllBaggage() Option {
 	return func(o *OTELConfig) {
 		o.Filter = BlockAllBaggage
 	}
@@ -103,7 +117,7 @@ var AllowAllBaggage baggagecopy.Filter = func(baggage.Member) bool { return true
 
 // WithAllowAllBaggage sets the OTELConfig to allow copying all memebers of baggage to
 // a span.
-func WithAllowAllBaggage() option {
+func WithAllowAllBaggage() Option {
 	return func(o *OTELConfig) {
 		o.Filter = AllowAllBaggage
 	}
@@ -116,5 +130,6 @@ func (oc OTELConfig) toInternalConfig() node.OTELConfig {
 		GRPCEndpoint:      oc.GRPCEndpoint,
 		Filter:            oc.Filter,
 		MeterExporterOpts: oc.meterExporterOpts,
+		Sampler:           oc.sampler,
 	}
 }

--- a/internal/node/otel.go
+++ b/internal/node/otel.go
@@ -117,6 +117,9 @@ type OTELConfig struct {
 
 	// MeterExporterOpts contains options to apply to the meter provider's exporter.
 	MeterExporterOpts []otlpmetricgrpc.Option
+
+	// Sampler controls trace sampling. Defaults to AlwaysSample when nil.
+	Sampler sdkTrace.Sampler
 }
 
 // ------------------------------------------------------------
@@ -173,7 +176,8 @@ func NewOTELClient(
 	client.TracerProvider, err = newTracerProvider(ctx,
 		client.grpcConn,
 		server,
-		config.Filter)
+		config.Filter,
+		config.Sampler)
 	if err != nil {
 		closeClient()
 		return nil, errors.Wrap(err, "generating a tracer provider")
@@ -231,6 +235,7 @@ func newTracerProvider(
 	conn *grpc.ClientConn,
 	server *resource.Resource,
 	filter baggagecopy.Filter,
+	sampler sdkTrace.Sampler,
 ) (*sdkTrace.TracerProvider, error) {
 	if ctx == nil {
 		return nil, errors.New("nil ctx")
@@ -252,14 +257,13 @@ func newTracerProvider(
 
 	baggageCopySpanProcessor := baggagecopy.NewSpanProcessor(filter)
 
+	if sampler == nil {
+		sampler = sdkTrace.AlwaysSample()
+	}
+
 	tracerProvider := sdkTrace.NewTracerProvider(
 		sdkTrace.WithResource(server),
-		// FIXME: need to investigate other options...
-		// * case handling for parent-not-sampled
-		// * blocking on full queue
-		// * max queue size
-		// FIXME: need to refine trace sampling.
-		sdkTrace.WithSampler(sdkTrace.AlwaysSample()),
+		sdkTrace.WithSampler(sampler),
 		sdkTrace.WithSpanProcessor(batchSpanProcessor),
 		sdkTrace.WithSpanProcessor(baggageCopySpanProcessor),
 		sdkTrace.WithRawSpanLimits(sdkTrace.SpanLimits{


### PR DESCRIPTION
`newTracerProvider` hardcodes `sdktrace.AlwaysSample()` with a `FIXME` comment — no way to override it from outside.

**Changes:**

`internal/node/otel.go`:
- Adds `Sampler sdkTrace.Sampler` field to `node.OTELConfig`
- `newTracerProvider` accepts `sampler` param; falls back to `AlwaysSample()` when nil — no behavior change for existing callers

`clutel/config.go`:
- Adds `sampler` field to `clutel.OTELConfig`
- Exports `option` → `Option` (was unexported, blocked external composition)
- Adds `WithTraceSampler(sdkTrace.Sampler) Option`
- `toInternalConfig()` passes sampler through

`clutel/clutel_test.go`:
- `TestWithTraceSampler`: verifies `NeverSample()` → `IsRecording() == false`, `AlwaysSample()` → `true`, default (nil) → `true`

**Usage:**

```go
cfg := clutel.NewConfig(
    resource,
    grpcEndpoint,
    clutel.WithTraceSampler(
        sdktrace.ParentBased(sdktrace.TraceIDRatioBased(0.1)),
    ),
)
ctx, err := clutel.Init(ctx, serviceName, cfg)
```