### PR TITLE
Allow custom bucket boundaries per Histogram

### DIFF
--- a/ctats/README.md
+++ b/ctats/README.md
@@ -106,8 +106,9 @@ about your data's distribution first. This is because the OTEL histograms
 store observations in pre-defined buckets. The default boundaries top out at
 **10,000** — anything above that disappears into an overflow bucket.
 
-[This explainer](https://signoz.io/blog/opentelemetry-histogram/) is a good read
-if you want a deeper understanding of OTEL Histograms.
+In case you're new to all this business,
+[here's a good read](https://signoz.io/blog/opentelemetry-histogram/)
+to catch you up with how histograms work under the hood.
 
 So, how do you set yourself up for histogram success using ctats?
 Just register your buckets on init!  Simple as that.

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -101,10 +101,10 @@ panic?
 
 ## Histograms
 
-Histograms are a bit more work than the other types because you have to think
-about your data's distribution first. This is because the OTEL histograms
-store observations in pre-defined buckets. The default boundaries top out at
-**10,000** — anything above that disappears into an overflow bucket.
+Histograms can be a bit more work than the other types because you have to think
+about your data's distribution ahead of time.  Sure, you can run with whatever
+OTEL uses as the default (15 buckets, scaling exponentially up to 10000), but is that
+really the best showcase for your data?  Probably not.
 
 In case you're new to all this business,
 [here's a good read](https://signoz.io/blog/opentelemetry-histogram/)

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -109,9 +109,8 @@ store observations in pre-defined buckets. The default boundaries top out at
 [This explainer](https://signoz.io/blog/opentelemetry-histogram/) is a good read
 if you want a deeper understanding of OTEL Histograms.
 
-However, the `ctats` API is just as easy to use as other metric types. The
-cleanest solution is to declare your histogram at startup with
-`RegisterHistogram`.
+So, how do you set yourself up for histogram success using ctats?
+Just register your buckets on init!  Simple as that.
 
 ```go
 func main() {

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -141,11 +141,10 @@ ignored.
 Use `MakeExponentialHistogramBoundaries` to generate logarithmically-spaced
 buckets. `min` and `max` determines the supported range of your metric.
 
-The optional `scalingFactor` controls how densely buckets are packed toward
-the low end of the range. At 1 (the default for any value ≤ 1) you get uniform
-log-spacing. Values greater than 1 warp the distribution so more bucket edges
-cluster near `min`, giving finer resolution where data is most likely to
-concentrate.
+The optional `scalingFactor` warps the bucket distribution. At 1 you get
+uniform log-spacing. Above 1, more edges cluster near `min` (useful for
+latency, where data tends to clump at the low end). Between 0 and 1, more
+edges cluster near `max`. Values ≤ 0 default to 1.
 
 ```go
 // example: measuring http server latencies in ms up to 60s

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -163,7 +163,7 @@ these simple questions and you'll be a master in no time!
 * Sum -> OTEL Counter
 * Counter -> OTEL UpDownCounter
 * Gauge -> OTEL Gauge (who knew?)
-* Histogram -> OTEL Histogram
+* Histogram -> OTEL Histogram (surprise!)
 
 Do you need `Delta Temporality`? Use a Sum, it's your only option!
 

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -139,12 +139,12 @@ ignored.
 ### Picking your boundaries
 
 Use `MakeExponentialHistogramBoundaries` to generate logarithmically-spaced
-buckets. `lo` and `hi` determine the supported range of your metric.
+buckets. `low` and `high` determine the supported range of your metric.
 
 The optional `scalingFactor` warps the bucket distribution. At 1 you get
-uniform log-spacing. Above 1, more edges cluster near `lo` (useful for
+uniform log-spacing. Above 1, more edges cluster near `low` (useful for
 latency, where data tends to clump at the low end). Between 0 and 1, more
-edges cluster near `hi`. Values ≤ 0 default to 1.
+edges cluster near `high`. Values ≤ 0 default to 1.
 
 ```go
 // example: measuring http server latencies in ms up to 60s

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -97,11 +97,48 @@ values are `float64`s behind the scenes. Easier to avoid the problem
 of potential conflicts altogether. What, would you prefer that we
 panic?
 
-## Corner Case: histogram bucket definitions
+## Histogram bucket boundaries
 
-You can't define your histogram buckets with Ctats. Why? Because
-[OTEL doesn't let you define them at runtime either](https://github.com/open-telemetry/opentelemetry-go/issues/3826).
-You'll have to take it up with the package authors, not us.
+The OTel Go SDK uses explicit bucket boundaries that top out at **10,000**
+by default Any observation above that ceiling lands in the `+Inf` overflow bucket.
+
+Boundaries can be passed to the OTel SDK at instrument creation time.
+They take effect only when **no matching View** has been configured on the
+`MeterProvider`; a View always takes precedence (per the OTel spec).
+
+Pass `WithBoundaries` when constructing a histogram to supply
+[explicit bucket boundaries](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation):
+
+`ctats.DefaultLatencyBoundariesMs` provides 20 logarithmically-spaced buckets from
+**1 to 60,000**. This is suitable for measuring latencies in milliseconds up to 60 seconds, with finer resolution and the low end of the range.
+
+```go
+ctats.Histogram[int64](
+    "op.latency_ms",
+    ctats.WithBoundaries(ctats.DefaultLatencyBoundariesMs...),
+).Record(ctx, elapsed)
+```
+
+Use `ExponentialBoundaries(min, max float64, count int)` to generate
+logarithmically-spaced buckets between any min/max with any resolution:
+
+```go
+boundaries := ctats.ExponentialBoundaries(1, 120_000, 30)
+
+ctats.Histogram[int64](
+    "op.latency_ms",
+    ctats.WithBoundaries(boundaries...),
+).Record(ctx, elapsed)
+```
+
+### Future: automatic exponential histograms
+
+The better long-term solution might be
+[`AggregationBase2ExponentialHistogram`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#AggregationBase2ExponentialHistogram)
+— it auto-scales and has no ceiling. However, the
+Elasticsearch [`exponential_histogram`](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/exponential-histogram)
+field type does **not yet support the `percentiles` aggregation**. Until ES ships that support, explicit bucket boundaries remain
+the only viable approach for percentile queries in Kibana.
 
 ## Sum vs Counter vs Gauge
 

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -12,7 +12,7 @@ _noun_
 
 OTEL metrics, despite being an invaluable addition to service telemetry,
 require an obnoxiously verbose setup and implementation. Ctats isn't
-here to provide any new features. Instead in wants to make the current
+here to provide any new features. Instead it wants to make the current
 features more accessible and less painful.
 
 ### Step 1: Init OTEL with Clues
@@ -36,7 +36,7 @@ func main() {
 ```go
 func main() {
   // ...
-   ctx, err = ctats.Initialize(ctx)
+  ctx, err = ctats.Initialize(ctx)
   // ...
 }
 ```
@@ -46,11 +46,11 @@ func main() {
 ```go
 func main() {
   // We're not kidding, this step is purely optional.
-  ctx, err := ctats.RegisterHistogram(
+  ctx, err := ctats.RegisterSum(
     ctx,
-    "http.server.latency", // Name
-    "ms", // Unit
-    "New user additions.", // Description
+    "http.server.requests", // Name
+    "1",                    // Unit
+    "Incoming HTTP requests by status code.", // Description
   )
 }
 ```
@@ -59,10 +59,12 @@ func main() {
 
 ```go
 func handler(ctx context.Context) {
-  //...
-  ctats.Histogram[int64]("http.server.latency").Record(latency)
-  //...
-
+  // ...
+  ctats.Sum[int64]("http.server.requests").
+    With("status_code", statusCode).
+    Inc(ctx)
+  // ...
+}
 ```
 
 ## How it works
@@ -97,50 +99,63 @@ values are `float64`s behind the scenes. Easier to avoid the problem
 of potential conflicts altogether. What, would you prefer that we
 panic?
 
-## Histogram bucket boundaries
+## Histograms
 
-The OTel Go SDK uses explicit bucket boundaries that top out at **10,000**
-by default Any observation above that ceiling lands in the `+Inf` overflow bucket.
+Histograms are a bit more work than the other types because you have to think
+about your data's distribution first. This is because the OTEL histograms
+store observations in pre-defined buckets. The default boundaries top out at
+**10,000** — anything above that disappears into an overflow bucket.
 
-Boundaries can be passed to the OTel SDK at instrument creation time.
-They take effect only when **no matching View** has been configured on the
-`MeterProvider`; a View always takes precedence (per the OTel spec).
+[this explainer](https://signoz.io/blog/opentelemetry-histogram/) is a good read
+if you want a deeper understanding of OTEL Histograms.
 
-Pass `WithBoundaries` when constructing a histogram to supply
-[explicit bucket boundaries](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation):
-
-`ctats.PresetLatencyBoundariesMs` provides 20 logarithmically-spaced buckets from
-**1 to 60,000**. This is suitable for measuring latencies in milliseconds up to 60 seconds, with finer resolution and the low end of the range.
+However, the `ctats` API is just as easy to use as other metric types. The
+cleanest solution is to declare your histogram at startup with
+`RegisterHistogram`.
 
 ```go
-ctats.Histogram[int64](
-    "op.latency_ms",
+func main() {
+  ctx, err := ctats.RegisterHistogram(
+    ctx,
+    "op.latency",
+    "ms",
+    "End-to-end operation latency.",
     ctats.WithBoundaries(ctats.PresetLatencyBoundariesMs...),
-).Record(ctx, elapsed)
+  )
+}
+
+func handler(ctx context.Context) {
+  ctats.Histogram[int64]("op.latency").Record(ctx, elapsed)
+}
 ```
 
-Use `ExponentialBoundaries(min, max float64, count int)` to generate
-logarithmically-spaced buckets between any min/max with any resolution:
+Still optional though. Pass `WithBoundaries` directly to the `Histogram`
+factory and the instrument is created on the first `Record` call. Just keep
+in mind that the first creation wins — if the same id was already registered
+or recorded against with different boundaries, the new ones are silently
+ignored. Again, would you prefer that we panic?
+
+### Picking your boundaries
+
+For latency in milliseconds, `PresetLatencyBoundariesMs` is a sensible
+default: 15 logarithmically-spaced buckets from **1 ms to 60,000 ms**, with
+finer resolution at the low end where most data clusters.
+
+If your data has a different shape, use `ExponentialBoundaries` to generate
+your own range. Note that `min` must be greater than zero — the boundaries
+are log-spaced so zero has no meaningful place in the range:
 
 ```go
-boundaries := ctats.ExponentialBoundaries(1, 120_000, 30)
+// background job duration in seconds: expected to time out at 1 hour
+boundaries := ctats.ExponentialBoundaries(1, 3_600, 10)
 
 ctats.Histogram[int64](
-    "op.latency_ms",
+    "job.duration",
     ctats.WithBoundaries(boundaries...),
 ).Record(ctx, elapsed)
 ```
 
-### Future: automatic exponential histograms
-
-The better long-term solution might be
-[`AggregationBase2ExponentialHistogram`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/metric#AggregationBase2ExponentialHistogram)
-— it auto-scales and has no ceiling. However, the
-Elasticsearch [`exponential_histogram`](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/exponential-histogram)
-field type does **not yet support the `percentiles` aggregation**. Until ES ships that support, explicit bucket boundaries remain
-the only viable approach for percentile queries in Kibana.
-
-## Sum vs Counter vs Gauge
+## Which metric type should I use?
 
 Feeling overwhelmed?  Not sure which type to pick?  Just answer
 these simple questions and you'll be a master in no time!
@@ -148,6 +163,7 @@ these simple questions and you'll be a master in no time!
 * Sum -> OTEL Counter
 * Counter -> OTEL UpDownCounter
 * Gauge -> OTEL Gauge (who knew?)
+* Histogram -> OTEL Histogram
 
 Do you need `Delta Temporality`? Use a Sum, it's your only option!
 
@@ -155,6 +171,8 @@ Do you need to decrement values? Use a Counter!
 
 Do you need have a single threaded, single source of truth? Try
 a Gauge!
+
+Do you need statistics such as percentiles? Use a Histogram!
 
 Sums are the most foolproof option all around.  Plug one in,
 count away.  Counters are nearly as good, if it weren't for the

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -109,13 +109,13 @@ They take effect only when **no matching View** has been configured on the
 Pass `WithBoundaries` when constructing a histogram to supply
 [explicit bucket boundaries](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation):
 
-`ctats.DefaultLatencyBoundariesMs` provides 20 logarithmically-spaced buckets from
+`ctats.PresetLatencyBoundariesMs` provides 20 logarithmically-spaced buckets from
 **1 to 60,000**. This is suitable for measuring latencies in milliseconds up to 60 seconds, with finer resolution and the low end of the range.
 
 ```go
 ctats.Histogram[int64](
     "op.latency_ms",
-    ctats.WithBoundaries(ctats.DefaultLatencyBoundariesMs...),
+    ctats.WithBoundaries(ctats.PresetLatencyBoundariesMs...),
 ).Record(ctx, elapsed)
 ```
 

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -148,7 +148,7 @@ cluster near `min`, giving finer resolution where data is most likely to
 concentrate.
 
 ```go
-// example 1: measuring http server latencies in ms up to 60s
+// example: measuring http server latencies in ms up to 60s
 boundaries := ctats.MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
 
 ctats.Histogram[int64](

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -115,12 +115,13 @@ Just register your buckets on init!  Simple as that.
 
 ```go
 func main() {
+  boundaries := ctats.MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
   ctx, err := ctats.RegisterHistogram(
     ctx,
     "op.latency",
     "ms",
     "End-to-end operation latency.",
-    ctats.WithBoundaries(ctats.PresetLatencyBoundariesMs...),
+    ctats.WithBoundaries(boundaries...),
   )
 }
 
@@ -137,17 +138,18 @@ ignored.
 
 ### Picking your boundaries
 
-For latency in milliseconds, `PresetLatencyBoundariesMs` is a sensible
-default: 15 logarithmically-spaced buckets from **1 ms to 60,000 ms**, with
-finer resolution at the low end where most data clusters.
+Use `MakeExponentialHistogramBoundaries` to generate logarithmically-spaced
+buckets. `min` and `max` determines the supported range of your metric.
 
-If your data has a different shape, use `ExponentialBoundaries` to generate
-your own range. Note that `min` must be greater than zero — the boundaries
-are log-spaced so zero has no meaningful place in the range:
+The optional `scalingFactor` controls how densely buckets are packed toward
+the low end of the range. At 1 (the default for any value ≤ 1) you get uniform
+log-spacing. Values greater than 1 warp the distribution so more bucket edges
+cluster near `min`, giving finer resolution where data is most likely to
+concentrate.
 
 ```go
-// background job duration in seconds: expected to time out at 1 hour
-boundaries := ctats.ExponentialBoundaries(1, 3_600, 10)
+// example 1: measuring http server latencies in ms up to 60s
+boundaries := ctats.MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
 
 ctats.Histogram[int64](
     "job.duration",

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -139,12 +139,12 @@ ignored.
 ### Picking your boundaries
 
 Use `MakeExponentialHistogramBoundaries` to generate logarithmically-spaced
-buckets. `min` and `max` determines the supported range of your metric.
+buckets. `lo` and `hi` determine the supported range of your metric.
 
 The optional `scalingFactor` warps the bucket distribution. At 1 you get
-uniform log-spacing. Above 1, more edges cluster near `min` (useful for
+uniform log-spacing. Above 1, more edges cluster near `lo` (useful for
 latency, where data tends to clump at the low end). Between 0 and 1, more
-edges cluster near `max`. Values ≤ 0 default to 1.
+edges cluster near `hi`. Values ≤ 0 default to 1.
 
 ```go
 // example: measuring http server latencies in ms up to 60s

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -106,7 +106,7 @@ about your data's distribution first. This is because the OTEL histograms
 store observations in pre-defined buckets. The default boundaries top out at
 **10,000** — anything above that disappears into an overflow bucket.
 
-[this explainer](https://signoz.io/blog/opentelemetry-histogram/) is a good read
+[This explainer](https://signoz.io/blog/opentelemetry-histogram/) is a good read
 if you want a deeper understanding of OTEL Histograms.
 
 However, the `ctats` API is just as easy to use as other metric types. The

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -133,7 +133,7 @@ Still optional though. Pass `WithBoundaries` directly to the `Histogram`
 factory and the instrument is created on the first `Record` call. Just keep
 in mind that the first creation wins — if the same id was already registered
 or recorded against with different boundaries, the new ones are silently
-ignored. Again, would you prefer that we panic?
+ignored.
 
 ### Picking your boundaries
 

--- a/ctats/README.md
+++ b/ctats/README.md
@@ -129,7 +129,7 @@ func handler(ctx context.Context) {
 }
 ```
 
-Still optional though. Pass `WithBoundaries` directly to the `Histogram`
+Registering is optional. You can also pass `WithBoundaries` directly to the
 factory and the instrument is created on the first `Record` call. Just keep
 in mind that the first creation wins — if the same id was already registered
 or recorded against with different boundaries, the new ones are silently

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -3,6 +3,7 @@ package ctats
 import (
 	"context"
 	"log"
+	"math"
 
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/metric"
@@ -11,12 +12,55 @@ import (
 	"github.com/alcionai/clues/internal/node"
 )
 
-// getOrCreateHistogram attempts to retrieve a histogram from the
-// context with the given ID.  If it is unable to find a histogram
-// with that ID, a new histogram is generated.
+// DefaultLatencyBoundariesMs are logarithmically-spaced bucket boundaries from
+// 1 to 60_000, suitable for measuring operation latency in milliseconds up to 60s.
+// Use with WithBoundaries to avoid the OTel SDK default ceiling of 10,000.
+var DefaultLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 20)
+
+// ExponentialBoundaries returns count boundaries spaced logarithmically between
+// min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:
+// https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#ExponentialBucketsRange
+//
+// Example:
+//
+//	ExponentialBoundaries(1, 60_000, 20)
+//	// → [1 2 3 6 10 18 32 58 103 183 327 584 1042 1859 3317 5919 10561 18845 33626 60000]
+func ExponentialBoundaries(min, max float64, count int) []float64 {
+	if count < 2 {
+		return []float64{min, max}
+	}
+
+	factor := math.Pow(max/min, 1/float64(count-1))
+	b := make([]float64, count)
+
+	for i := range b {
+		b[i] = math.Round(min * math.Pow(factor, float64(i)))
+	}
+
+	b[count-1] = max // guarantee exact ceiling, no rounding drift
+
+	return b
+}
+
+type HistogramOption func(*histogramConfig)
+
+type histogramConfig struct {
+	boundaries []float64
+}
+
+// WithBoundaries sets explicit bucket boundaries on the histogram.
+// Boundaries are passed to the OTel SDK at instrument creation time and are
+// ignored if a matching MeterProvider View is already configured.
+func WithBoundaries(boundaries ...float64) HistogramOption {
+	return func(c *histogramConfig) {
+		c.boundaries = boundaries
+	}
+}
+
 func getOrCreateHistogram(
 	ctx context.Context,
 	id string,
+	boundaries []float64,
 ) (recorder, error) {
 	id = formatID(id)
 	b := fromCtx(ctx)
@@ -36,7 +80,12 @@ func getOrCreateHistogram(
 		return nil, cluerr.Stack(errNoNodeInCtx)
 	}
 
-	hist, err := nc.OTELMeter().Float64Histogram(id)
+	var opts []metric.Float64HistogramOption
+	if len(boundaries) > 0 {
+		opts = append(opts, metric.WithExplicitBucketBoundaries(boundaries...))
+	}
+
+	hist, err := nc.OTELMeter().Float64Histogram(id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "making new histogram")
 	}
@@ -61,6 +110,7 @@ func RegisterHistogram(
 	// (optional) a short description about the metric.
 	// Ex: "number of times we saw the fnords".
 	description string,
+	opts ...HistogramOption,
 ) (context.Context, error) {
 	id = formatID(id)
 
@@ -82,18 +132,26 @@ func RegisterHistogram(
 		return ctx, errors.New("no clues in ctx")
 	}
 
-	opts := []metric.Float64HistogramOption{}
+	cfg := &histogramConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	var instrumentOpts []metric.Float64HistogramOption
 
 	if len(description) > 0 {
-		opts = append(opts, metric.WithDescription(description))
+		instrumentOpts = append(instrumentOpts, metric.WithDescription(description))
 	}
 
 	if len(unit) > 0 {
-		opts = append(opts, metric.WithUnit(unit))
+		instrumentOpts = append(instrumentOpts, metric.WithUnit(unit))
 	}
 
-	// register the histogram
-	hist, err := nc.OTELMeter().Float64Histogram(id, opts...)
+	if len(cfg.boundaries) > 0 {
+		instrumentOpts = append(instrumentOpts, metric.WithExplicitBucketBoundaries(cfg.boundaries...))
+	}
+
+	hist, err := nc.OTELMeter().Float64Histogram(id, instrumentOpts...)
 	if err != nil {
 		return ctx, errors.Wrap(err, "creating histogram")
 	}
@@ -103,21 +161,29 @@ func RegisterHistogram(
 	return embedInCtx(ctx, b), nil
 }
 
-// Histogram returns a histogram factory for the provided id.
-// If a Histogram instance has been registered for that ID, the
-// registered instance will be used.  If not, a new instance
-// will get generated.
-func Histogram[N number](id string) histogram[N] {
-	return histogram[N]{base: base{id: formatID(id)}}
+// Histogram returns a histogram factory for the given id. If the id was
+// previously registered via RegisterHistogram that instance is reused;
+// otherwise a new one is created on the first Record call.
+func Histogram[N number](id string, opts ...HistogramOption) histogram[N] {
+	cfg := &histogramConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	return histogram[N]{
+		base:       base{id: formatID(id)},
+		boundaries: cfg.boundaries,
+	}
 }
 
 // histogram provides access to the factory functions.
 type histogram[N number] struct {
 	base
+	boundaries []float64
 }
 
 func (c histogram[N]) With(kvs ...any) histogram[N] {
-	return histogram[N]{base: c.with(kvs...)}
+	return histogram[N]{base: c.with(kvs...), boundaries: c.boundaries}
 }
 
 type recorder interface {
@@ -130,7 +196,7 @@ func (n noopRecorder) Record(context.Context, float64, ...metric.RecordOption) {
 
 // Add increments the histogram by n. n can be negative.
 func (c histogram[number]) Record(ctx context.Context, n number) {
-	hist, err := getOrCreateHistogram(ctx, c.getID())
+	hist, err := getOrCreateHistogram(ctx, c.getID(), c.boundaries)
 	if err != nil {
 		log.Printf("err getting histogram: %+v\n", err)
 		return

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -42,17 +42,17 @@ func ExponentialBoundaries(min, max float64, count int) []float64 {
 	return b
 }
 
-type HistogramOption func(*histogramConfig)
-
-type histogramConfig struct {
+type histogramCfg struct {
 	boundaries []float64
 }
+
+type HistogramOption func(*histogramCfg)
 
 // WithBoundaries sets explicit bucket boundaries on the histogram.
 // Boundaries are passed to the OTel SDK at instrument creation time and are
 // ignored if a matching MeterProvider View is already configured.
 func WithBoundaries(boundaries ...float64) HistogramOption {
-	return func(c *histogramConfig) {
+	return func(c *histogramCfg) {
 		c.boundaries = boundaries
 	}
 }
@@ -99,17 +99,18 @@ func getOrCreateHistogram(
 
 // RegisterHistogram introduces a new histogram with the given unit and description.
 // If RegisterHistogram is not called before updating a metric value, a histogram with
-// no unit or description is created.  If RegisterHistogram is called for an ID that
+// no unit or description is created. If RegisterHistogram is called for an ID that
 // has already been registered, it no-ops.
 func RegisterHistogram(
 	ctx context.Context,
-	// all lowercase, period delimited id of the histogram. Ex: "http.response.status_code"
+	// all lowercase, period delimited id of the histogram. Ex: "http.response.size"
 	id string,
 	// (optional) the unit of measurement.  Ex: "byte", "kB", "fnords"
 	unit string,
 	// (optional) a short description about the metric.
 	// Ex: "number of times we saw the fnords".
 	description string,
+	// (optional) histogram specific options
 	opts ...HistogramOption,
 ) (context.Context, error) {
 	id = formatID(id)
@@ -132,26 +133,26 @@ func RegisterHistogram(
 		return ctx, errors.New("no clues in ctx")
 	}
 
-	cfg := &histogramConfig{}
+	var cfg histogramCfg
 	for _, o := range opts {
-		o(cfg)
+		o(&cfg)
 	}
 
-	var instrumentOpts []metric.Float64HistogramOption
+	var metricHistogramOpts []metric.Float64HistogramOption
 
 	if len(description) > 0 {
-		instrumentOpts = append(instrumentOpts, metric.WithDescription(description))
+		metricHistogramOpts = append(metricHistogramOpts, metric.WithDescription(description))
 	}
 
 	if len(unit) > 0 {
-		instrumentOpts = append(instrumentOpts, metric.WithUnit(unit))
+		metricHistogramOpts = append(metricHistogramOpts, metric.WithUnit(unit))
 	}
 
 	if len(cfg.boundaries) > 0 {
-		instrumentOpts = append(instrumentOpts, metric.WithExplicitBucketBoundaries(cfg.boundaries...))
+		metricHistogramOpts = append(metricHistogramOpts, metric.WithExplicitBucketBoundaries(cfg.boundaries...))
 	}
 
-	hist, err := nc.OTELMeter().Float64Histogram(id, instrumentOpts...)
+	hist, err := nc.OTELMeter().Float64Histogram(id, metricHistogramOpts...)
 	if err != nil {
 		return ctx, errors.Wrap(err, "creating histogram")
 	}
@@ -165,25 +166,22 @@ func RegisterHistogram(
 // previously registered via RegisterHistogram that instance is reused;
 // otherwise a new one is created on the first Record call.
 func Histogram[N number](id string, opts ...HistogramOption) histogram[N] {
-	cfg := &histogramConfig{}
+	hgm := histogram[N]{base: base{id: formatID(id)}}
 	for _, o := range opts {
-		o(cfg)
+		o(&hgm.histogramCfg)
 	}
 
-	return histogram[N]{
-		base:       base{id: formatID(id)},
-		boundaries: cfg.boundaries,
-	}
+	return hgm
 }
 
 // histogram provides access to the factory functions.
 type histogram[N number] struct {
 	base
-	boundaries []float64
+	histogramCfg
 }
 
 func (c histogram[N]) With(kvs ...any) histogram[N] {
-	return histogram[N]{base: c.with(kvs...), boundaries: c.boundaries}
+	return histogram[N]{base: c.with(kvs...), histogramCfg: c.histogramCfg}
 }
 
 type recorder interface {
@@ -194,7 +192,7 @@ type noopRecorder struct{}
 
 func (n noopRecorder) Record(context.Context, float64, ...metric.RecordOption) {}
 
-// Add increments the histogram by n. n can be negative.
+// Record records the measurement of n in the histogram.
 func (c histogram[number]) Record(ctx context.Context, n number) {
 	hist, err := getOrCreateHistogram(ctx, c.getID(), c.boundaries)
 	if err != nil {

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -12,10 +12,9 @@ import (
 	"github.com/alcionai/clues/internal/node"
 )
 
-// DefaultLatencyBoundariesMs are logarithmically-spaced bucket boundaries from
+// PresetLatencyBoundariesMs are logarithmically-spaced bucket boundaries from
 // 1 to 60_000, suitable for measuring operation latency in milliseconds up to 60s.
-// Use with WithBoundaries to avoid the OTel SDK default ceiling of 10,000.
-var DefaultLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 20)
+var PresetLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 20)
 
 // ExponentialBoundaries returns count boundaries spaced logarithmically between
 // min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -17,23 +17,24 @@ import (
 // and how boundaries map to OTel buckets, see the OTel metrics SDK spec:
 // https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation
 //
-// scalingFactor controls how densely buckets are packed toward the low end of the
-// range. At 1 (the default for any value ≤ 1), positions are uniformly log-spaced —
-// constant growth ratio between consecutive buckets. Values greater than 1 warp the
-// position distribution so that more bucket edges cluster near min.
+// scalingFactor warps the position distribution between min and max. At 1,
+// positions are uniformly log-spaced — constant growth ratio. Values above 1
+// pack more buckets toward min (useful when data clusters at the low end).
+// Values between 0 and 1 pack more buckets toward max. Values ≤ 0 are invalid
+// and default to 1.
 //
 // Example:
 //
 //	MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
 //	// → [1 2 5 11 23 51 112 245 537 1179 2588 5679 12461 27344 60000]
 //
-//	MakeExponentialHistogramBoundaries(10, 1000, 5, 1)
-//	// → [10 32 100 316 1000]   (uniform log-spacing)
+//	MakeExponentialHistogramBoundaries(10, 1000, 5, 0.5)
+//	// → [10 100 260 540 1000]  (denser at high end)
 //
 //	MakeExponentialHistogramBoundaries(10, 1000, 5, 2)
-//	// → [10 13 32 133 1000]    (denser at low end, same range)
+//	// → [10 13 32 133 1000]    (denser at low end)
 func MakeExponentialHistogramBoundaries(min, max float64, count int, scalingFactor float64) []float64 {
-	if scalingFactor <= 1 {
+	if scalingFactor <= 0 {
 		scalingFactor = 1
 	}
 

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -13,8 +13,9 @@ import (
 )
 
 // MakeExponentialHistogramBoundaries returns count boundaries spaced logarithmically
-// between min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:
-// https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#ExponentialBucketsRange
+// between min and max (both inclusive). For background on explicit bucket histograms
+// and how boundaries map to OTel buckets, see the OTel metrics SDK spec:
+// https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation
 //
 // scalingFactor controls how densely buckets are packed toward the low end of the
 // range. At 1 (the default for any value ≤ 1), positions are uniformly log-spaced —

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -58,6 +58,14 @@ type histogramCfg struct {
 	boundaries []float64
 }
 
+func (c histogramCfg) appendOpts(opts []metric.Float64HistogramOption) []metric.Float64HistogramOption {
+	if len(c.boundaries) > 0 {
+		opts = append(opts, metric.WithExplicitBucketBoundaries(c.boundaries...))
+	}
+
+	return opts
+}
+
 type HistogramOption func(*histogramCfg)
 
 // WithBoundaries sets explicit bucket boundaries on the histogram.
@@ -75,7 +83,7 @@ func WithBoundaries(boundaries ...float64) HistogramOption {
 func getOrCreateHistogram(
 	ctx context.Context,
 	id string,
-	boundaries []float64,
+	cfg histogramCfg,
 ) (recorder, error) {
 	id = formatID(id)
 	b := fromCtx(ctx)
@@ -95,10 +103,7 @@ func getOrCreateHistogram(
 		return nil, cluerr.Stack(errNoNodeInCtx)
 	}
 
-	var opts []metric.Float64HistogramOption
-	if len(boundaries) > 0 {
-		opts = append(opts, metric.WithExplicitBucketBoundaries(boundaries...))
-	}
+	opts := cfg.appendOpts(nil)
 
 	// register the histogram
 	hist, err := nc.OTELMeter().Float64Histogram(id, opts...)
@@ -164,9 +169,7 @@ func RegisterHistogram(
 		metricHistogramOpts = append(metricHistogramOpts, metric.WithUnit(unit))
 	}
 
-	if len(cfg.boundaries) > 0 {
-		metricHistogramOpts = append(metricHistogramOpts, metric.WithExplicitBucketBoundaries(cfg.boundaries...))
-	}
+	metricHistogramOpts = cfg.appendOpts(metricHistogramOpts)
 
 	hist, err := nc.OTELMeter().Float64Histogram(id, metricHistogramOpts...)
 	if err != nil {
@@ -211,7 +214,7 @@ func (n noopRecorder) Record(context.Context, float64, ...metric.RecordOption) {
 
 // Record records the measurement of n in the histogram.
 func (c histogram[number]) Record(ctx context.Context, n number) {
-	hist, err := getOrCreateHistogram(ctx, c.getID(), c.boundaries)
+	hist, err := getOrCreateHistogram(ctx, c.getID(), c.histogramCfg)
 	if err != nil {
 		log.Printf("err getting histogram: %+v\n", err)
 		return

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -14,7 +14,7 @@ import (
 
 // PresetLatencyBoundariesMs are logarithmically-spaced bucket boundaries from
 // 1 to 60_000, suitable for measuring operation latency in milliseconds up to 60s.
-var PresetLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 20)
+var PresetLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 15)
 
 // ExponentialBoundaries returns count boundaries spaced logarithmically between
 // min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -13,15 +13,15 @@ import (
 )
 
 // MakeExponentialHistogramBoundaries returns count boundaries spaced logarithmically
-// between lo and hi (both inclusive). For background on explicit bucket histograms
+// between low and high (both inclusive). For background on explicit bucket histograms
 // and how boundaries map to OTel buckets, see the OTel metrics SDK spec
 // (navigate to the "Explicit Bucket Histogram Aggregation" section):
 // https://opentelemetry.io/docs/specs/otel/metrics/sdk/
 //
-// scalingFactor warps the position distribution between lo and hi. At 1,
+// scalingFactor warps the position distribution between low and high. At 1,
 // positions are uniformly log-spaced — constant growth ratio. Values above 1
-// pack more buckets toward lo (useful when data clusters at the low end).
-// Values between 0 and 1 pack more buckets toward hi. Values ≤ 0 are invalid
+// pack more buckets toward low (useful when data clusters at the low end).
+// Values between 0 and 1 pack more buckets toward high. Values ≤ 0 are invalid
 // and default to 1.
 //
 // Example:
@@ -38,7 +38,7 @@ import (
 //	MakeExponentialHistogramBoundaries(10, 1000, 5, 2)
 //	// → [10 13 32 133 1000]    (denser at low end)
 func MakeExponentialHistogramBoundaries(
-	lo, hi float64,
+	low, high float64,
 	count int,
 	scalingFactor float64,
 ) []float64 {
@@ -47,18 +47,18 @@ func MakeExponentialHistogramBoundaries(
 	}
 
 	if count < 2 {
-		return []float64{lo, hi}
+		return []float64{low, high}
 	}
 
 	b := make([]float64, count)
 
 	for i := range b {
 		t := math.Pow(float64(i)/float64(count-1), scalingFactor)
-		b[i] = math.Round(lo * math.Pow(hi/lo, t))
+		b[i] = math.Round(low * math.Pow(high/low, t))
 	}
 
-	b[0] = lo       // guarantee exact floor, no rounding drift
-	b[count-1] = hi // guarantee exact ceiling, no rounding drift
+	b[0] = low        // guarantee exact floor, no rounding drift
+	b[count-1] = high // guarantee exact ceiling, no rounding drift
 
 	return b
 }

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -12,30 +12,42 @@ import (
 	"github.com/alcionai/clues/internal/node"
 )
 
-// PresetLatencyBoundariesMs are logarithmically-spaced bucket boundaries from
-// 1 to 60_000, suitable for measuring operation latency in milliseconds up to 60s.
-var PresetLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 15)
-
-// ExponentialBoundaries returns count boundaries spaced logarithmically between
-// min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:
+// MakeExponentialHistogramBoundaries returns count boundaries spaced logarithmically
+// between min and max (both inclusive), mirroring Prometheus's ExponentialBucketsRange:
 // https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#ExponentialBucketsRange
+//
+// scalingFactor controls how densely buckets are packed toward the low end of the
+// range. At 1 (the default for any value ≤ 1), positions are uniformly log-spaced —
+// constant growth ratio between consecutive buckets. Values greater than 1 warp the
+// position distribution so that more bucket edges cluster near min.
 //
 // Example:
 //
-//	ExponentialBoundaries(1, 60_000, 15)
+//	MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
 //	// → [1 2 5 11 23 51 112 245 537 1179 2588 5679 12461 27344 60000]
-func ExponentialBoundaries(min, max float64, count int) []float64 {
+//
+//	MakeExponentialHistogramBoundaries(10, 1000, 5, 1)
+//	// → [10 32 100 316 1000]   (uniform log-spacing)
+//
+//	MakeExponentialHistogramBoundaries(10, 1000, 5, 2)
+//	// → [10 13 32 133 1000]    (denser at low end, same range)
+func MakeExponentialHistogramBoundaries(min, max float64, count int, scalingFactor float64) []float64 {
+	if scalingFactor <= 1 {
+		scalingFactor = 1
+	}
+
 	if count < 2 {
 		return []float64{min, max}
 	}
 
-	factor := math.Pow(max/min, 1/float64(count-1))
 	b := make([]float64, count)
 
 	for i := range b {
-		b[i] = math.Round(min * math.Pow(factor, float64(i)))
+		t := math.Pow(float64(i)/float64(count-1), scalingFactor)
+		b[i] = math.Round(min * math.Pow(max/min, t))
 	}
 
+	b[0] = min       // guarantee exact floor, no rounding drift
 	b[count-1] = max // guarantee exact ceiling, no rounding drift
 
 	return b

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -13,14 +13,15 @@ import (
 )
 
 // MakeExponentialHistogramBoundaries returns count boundaries spaced logarithmically
-// between min and max (both inclusive). For background on explicit bucket histograms
-// and how boundaries map to OTel buckets, see the OTel metrics SDK spec:
-// https://opentelemetry.io/docs/specs/otel/metrics/sdk/#explicit-bucket-histogram-aggregation
+// between lo and hi (both inclusive). For background on explicit bucket histograms
+// and how boundaries map to OTel buckets, see the OTel metrics SDK spec
+// (navigate to the "Explicit Bucket Histogram Aggregation" section):
+// https://opentelemetry.io/docs/specs/otel/metrics/sdk/
 //
-// scalingFactor warps the position distribution between min and max. At 1,
+// scalingFactor warps the position distribution between lo and hi. At 1,
 // positions are uniformly log-spaced — constant growth ratio. Values above 1
-// pack more buckets toward min (useful when data clusters at the low end).
-// Values between 0 and 1 pack more buckets toward max. Values ≤ 0 are invalid
+// pack more buckets toward lo (useful when data clusters at the low end).
+// Values between 0 and 1 pack more buckets toward hi. Values ≤ 0 are invalid
 // and default to 1.
 //
 // Example:
@@ -31,26 +32,33 @@ import (
 //	MakeExponentialHistogramBoundaries(10, 1000, 5, 0.5)
 //	// → [10 100 260 540 1000]  (denser at high end)
 //
+//	MakeExponentialHistogramBoundaries(10, 1000, 5, 1)
+//	// → [10 32 100 316 1000]   (uniform log-spacing)
+//
 //	MakeExponentialHistogramBoundaries(10, 1000, 5, 2)
 //	// → [10 13 32 133 1000]    (denser at low end)
-func MakeExponentialHistogramBoundaries(min, max float64, count int, scalingFactor float64) []float64 {
+func MakeExponentialHistogramBoundaries(
+	lo, hi float64,
+	count int,
+	scalingFactor float64,
+) []float64 {
 	if scalingFactor <= 0 {
 		scalingFactor = 1
 	}
 
 	if count < 2 {
-		return []float64{min, max}
+		return []float64{lo, hi}
 	}
 
 	b := make([]float64, count)
 
 	for i := range b {
 		t := math.Pow(float64(i)/float64(count-1), scalingFactor)
-		b[i] = math.Round(min * math.Pow(max/min, t))
+		b[i] = math.Round(lo * math.Pow(hi/lo, t))
 	}
 
-	b[0] = min       // guarantee exact floor, no rounding drift
-	b[count-1] = max // guarantee exact ceiling, no rounding drift
+	b[0] = lo       // guarantee exact floor, no rounding drift
+	b[count-1] = hi // guarantee exact ceiling, no rounding drift
 
 	return b
 }
@@ -59,7 +67,9 @@ type histogramCfg struct {
 	boundaries []float64
 }
 
-func (c histogramCfg) appendOpts(opts []metric.Float64HistogramOption) []metric.Float64HistogramOption {
+func (c histogramCfg) appendOpts(
+	opts ...metric.Float64HistogramOption,
+) []metric.Float64HistogramOption {
 	if len(c.boundaries) > 0 {
 		opts = append(opts, metric.WithExplicitBucketBoundaries(c.boundaries...))
 	}
@@ -104,7 +114,7 @@ func getOrCreateHistogram(
 		return nil, cluerr.Stack(errNoNodeInCtx)
 	}
 
-	opts := cfg.appendOpts(nil)
+	opts := cfg.appendOpts()
 
 	// register the histogram
 	hist, err := nc.OTELMeter().Float64Histogram(id, opts...)
@@ -170,7 +180,7 @@ func RegisterHistogram(
 		metricHistogramOpts = append(metricHistogramOpts, metric.WithUnit(unit))
 	}
 
-	metricHistogramOpts = cfg.appendOpts(metricHistogramOpts)
+	metricHistogramOpts = cfg.appendOpts(metricHistogramOpts...)
 
 	hist, err := nc.OTELMeter().Float64Histogram(id, metricHistogramOpts...)
 	if err != nil {

--- a/ctats/histogram.go
+++ b/ctats/histogram.go
@@ -22,8 +22,8 @@ var PresetLatencyBoundariesMs = ExponentialBoundaries(1, 60_000, 15)
 //
 // Example:
 //
-//	ExponentialBoundaries(1, 60_000, 20)
-//	// → [1 2 3 6 10 18 32 58 103 183 327 584 1042 1859 3317 5919 10561 18845 33626 60000]
+//	ExponentialBoundaries(1, 60_000, 15)
+//	// → [1 2 5 11 23 51 112 245 537 1179 2588 5679 12461 27344 60000]
 func ExponentialBoundaries(min, max float64, count int) []float64 {
 	if count < 2 {
 		return []float64{min, max}
@@ -56,6 +56,9 @@ func WithBoundaries(boundaries ...float64) HistogramOption {
 	}
 }
 
+// getOrCreateHistogram attempts to retrieve a histogram from the
+// context with the given ID.  If it is unable to find a histogram
+// with that ID, a new histogram is generated.
 func getOrCreateHistogram(
 	ctx context.Context,
 	id string,
@@ -84,6 +87,7 @@ func getOrCreateHistogram(
 		opts = append(opts, metric.WithExplicitBucketBoundaries(boundaries...))
 	}
 
+	// register the histogram
 	hist, err := nc.OTELMeter().Float64Histogram(id, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "making new histogram")
@@ -161,9 +165,10 @@ func RegisterHistogram(
 	return embedInCtx(ctx, b), nil
 }
 
-// Histogram returns a histogram factory for the given id. If the id was
-// previously registered via RegisterHistogram that instance is reused;
-// otherwise a new one is created on the first Record call.
+// Histogram returns a histogram factory for the provided id.
+// If a Histogram instance has been registered for that ID, the
+// registered instance will be used.  If not, a new instance
+// will get generated.
 func Histogram[N number](id string, opts ...HistogramOption) histogram[N] {
 	hgm := histogram[N]{base: base{id: formatID(id)}}
 	for _, o := range opts {

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	sdkMetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/alcionai/clues/internal/node"
 )
 
 func TestHistogram(t *testing.T) {
@@ -101,4 +105,223 @@ func TestHistogramWithDoesNotMutateBase(t *testing.T) {
 
 	assert.Equal(t, attrs, withAttrs.getOTELKVAttrs())
 	assert.Len(t, second.getOTELKVAttrs(), 2)
+}
+
+// ---------------------------------------------------------------------------
+// ExponentialBoundaries
+// ---------------------------------------------------------------------------
+
+func TestExponentialBoundaries(t *testing.T) {
+	testCases := []struct {
+		name    string
+		min     float64
+		max     float64
+		count   int
+		wantLen int
+		wantMin float64
+		wantMax float64
+	}{
+		{
+			name:    "standard 20-bucket latency range",
+			min:     1,
+			max:     60_000,
+			count:   20,
+			wantLen: 20,
+			wantMin: 1,
+			wantMax: 60_000,
+		},
+		{
+			name:    "small count",
+			min:     10,
+			max:     1000,
+			count:   5,
+			wantLen: 5,
+			wantMin: 10,
+			wantMax: 1000,
+		},
+		{
+			name:    "count less than 2 returns min and max",
+			min:     1,
+			max:     100,
+			count:   1,
+			wantLen: 2,
+			wantMin: 1,
+			wantMax: 100,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			got := ExponentialBoundaries(test.min, test.max, test.count)
+
+			require.Len(t, got, test.wantLen, "boundary count")
+			assert.Equal(t, test.wantMin, got[0], "first boundary must equal min")
+			assert.Equal(t, test.wantMax, got[len(got)-1], "last boundary must equal max")
+
+			for i := 1; i < len(got); i++ {
+				assert.Greater(t, got[i], got[i-1], "boundaries must be strictly increasing at index %d", i)
+			}
+		})
+	}
+}
+
+func TestExponentialBoundariesDefaultLatencyValues(t *testing.T) {
+	// Spot-check the documented example output for ExponentialBoundaries(1, 60_000, 20).
+	got := ExponentialBoundaries(1, 60_000, 20)
+
+	require.Len(t, got, 20)
+	assert.Equal(t, float64(1), got[0])
+	assert.Equal(t, float64(60_000), got[19])
+
+	// Mid-range spot checks.
+	assert.Equal(t, float64(10), got[4])
+	assert.Equal(t, float64(327), got[10])
+	assert.Equal(t, float64(10561), got[16])
+}
+
+// ---------------------------------------------------------------------------
+// DefaultLatencyBoundariesMs
+// ---------------------------------------------------------------------------
+
+func TestDefaultLatencyBoundariesMs(t *testing.T) {
+	assert.Len(t, DefaultLatencyBoundariesMs, 20, "should have 20 buckets")
+	assert.Equal(t, float64(1), DefaultLatencyBoundariesMs[0], "first boundary is 1 ms")
+	assert.Equal(t, float64(60_000), DefaultLatencyBoundariesMs[19], "last boundary is 60,000 ms")
+
+	for i := 1; i < len(DefaultLatencyBoundariesMs); i++ {
+		assert.Greater(
+			t,
+			DefaultLatencyBoundariesMs[i],
+			DefaultLatencyBoundariesMs[i-1],
+			"boundaries must be strictly increasing at index %d",
+			i,
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithBoundaries option
+// ---------------------------------------------------------------------------
+
+func TestHistogramWithBoundariesOption(t *testing.T) {
+	want := []float64{1, 10, 100, 1000}
+
+	h := Histogram[int64]("bounds.hist", WithBoundaries(want...))
+
+	assert.Equal(t, want, h.boundaries)
+}
+
+func TestHistogramWithBoundariesPreservedByWith(t *testing.T) {
+	boundaries := []float64{5, 50, 500}
+
+	base := Histogram[int64]("preserve.bounds", WithBoundaries(boundaries...))
+	child := base.With("key", "val")
+
+	assert.Equal(t, boundaries, base.boundaries, "base boundaries unchanged")
+	assert.Equal(t, boundaries, child.boundaries, "With must copy boundaries to child")
+}
+
+func TestHistogramWithBoundariesDoesNotMutateBase(t *testing.T) {
+	boundaries := []float64{1, 2, 3}
+
+	base := Histogram[int64]("nomutate.bounds", WithBoundaries(boundaries...))
+	assert.Nil(t, base.getOTELKVAttrs(), "base has no attributes before With")
+
+	child := base.With("k", "v")
+
+	assert.Nil(t, base.getOTELKVAttrs(), "base attributes still nil after With")
+	assert.Len(t, child.getOTELKVAttrs(), 1)
+	assert.Equal(t, boundaries, child.boundaries, "child carries boundaries")
+}
+
+func TestHistogramNoBoundariesByDefault(t *testing.T) {
+	h := Histogram[float64]("no.bounds")
+	assert.Nil(t, h.boundaries, "no boundaries by default")
+}
+
+// ---------------------------------------------------------------------------
+// Record end-to-end with real OTel MeterProvider
+// ---------------------------------------------------------------------------
+
+// ctatsCtx returns a context wired with a real OTel MeterProvider backed by
+// the given ManualReader, suitable for testing ctats.Record end-to-end.
+func ctatsCtx(t *testing.T, reader *sdkMetric.ManualReader) context.Context {
+	t.Helper()
+
+	mp := sdkMetric.NewMeterProvider(sdkMetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	otelClient := &node.OTELClient{
+		Meter:         mp.Meter("ctats-test"),
+		MeterProvider: mp,
+	}
+
+	n := &node.Node{OTEL: otelClient}
+	ctx := node.EmbedInCtx(context.Background(), n)
+
+	ctx, err := Initialize(ctx)
+	require.NoError(t, err)
+
+	return ctx
+}
+
+// collectHistogram retrieves the first data point for a named histogram from a
+// ManualReader snapshot.
+func collectHistogram(
+	t *testing.T,
+	reader *sdkMetric.ManualReader,
+	name string,
+) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				h, ok := m.Data.(metricdata.Histogram[float64])
+				require.True(t, ok, "metric %q is not a Histogram[float64]", name)
+				require.NotEmpty(t, h.DataPoints)
+				return h.DataPoints[0]
+			}
+		}
+	}
+
+	t.Fatalf("histogram %q not found", name)
+
+	return metricdata.HistogramDataPoint[float64]{}
+}
+
+// TestRecordWithDefaultLatencyBoundaries records a 15,000 ms value through the
+// full ctats.Record path.
+//
+// 15,000 falls between bounds[16]=10,561 and bounds[17]=18,845 → bucket index 17.
+func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
+	reader := sdkMetric.NewManualReader()
+	ctx := ctatsCtx(t, reader)
+
+	Histogram[int64]("op.latency", WithBoundaries(DefaultLatencyBoundariesMs...)).Record(ctx, 15_000)
+
+	dp := collectHistogram(t, reader, "op.latency")
+
+	assert.Equal(t, float64(60_000), dp.Bounds[len(dp.Bounds)-1], "last boundary is 60,000 ms")
+	assert.Equal(t, uint64(0), dp.BucketCounts[len(dp.BucketCounts)-1], "no overflow")
+
+	// 15,000 ms sits between bounds[16]=10,561 and bounds[17]=18,845
+	assert.Equal(t, uint64(1), dp.BucketCounts[17], "15,000 ms lands in bucket 17 (10561–18845 ms)")
+}
+
+// TestRecordDefaultOTelBoundariesOverflow shows that without WithBoundaries,
+// the OTel SDK default ceiling of 10,000 ms causes 15,000 ms to overflow.
+func TestRecordDefaultOTelBoundariesOverflow(t *testing.T) {
+	reader := sdkMetric.NewManualReader()
+	ctx := ctatsCtx(t, reader)
+
+	Histogram[int64]("op.latency.default").Record(ctx, 15_000)
+
+	dp := collectHistogram(t, reader, "op.latency.default")
+
+	assert.Equal(t, float64(10_000), dp.Bounds[len(dp.Bounds)-1], "default ceiling is 10,000 ms")
+	assert.Equal(t, uint64(1), dp.BucketCounts[len(dp.BucketCounts)-1], "15,000 ms overflows to +Inf")
 }

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -128,18 +128,13 @@ func TestBoundaries(t *testing.T) {
 			want: []float64{1, 100},
 		},
 		{
-			name: "scaling factor 0 treated as 1 (no-op)",
+			name: "scaling factor 0 is invalid - defaults to 1",
 			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 0),
 			want: []float64{10, 32, 100, 316, 1000},
 		},
 		{
-			name: "negative scaling factor treated as 1 (no-op)",
+			name: "negative scaling factor is invalid - defaults to 1",
 			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, -3),
-			want: []float64{10, 32, 100, 316, 1000},
-		},
-		{
-			name: "5 buckets, uniform log-spacing",
-			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 1),
 			want: []float64{10, 32, 100, 316, 1000},
 		},
 		{
@@ -151,6 +146,16 @@ func TestBoundaries(t *testing.T) {
 			name: "20 buckets, uniform log-spacing",
 			got:  MakeExponentialHistogramBoundaries(1, 60_000, 20, 1),
 			want: []float64{1, 2, 3, 6, 10, 18, 32, 58, 103, 183, 327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000},
+		},
+		{
+			name: "scaling factor 0.5: finer resolution at high end, min and max preserved",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 0.5),
+			want: []float64{10, 100, 260, 540, 1000},
+		},
+		{
+			name: "5 buckets, uniform log-spacing",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 1),
+			want: []float64{10, 32, 100, 316, 1000},
 		},
 		{
 			name: "scaling factor 2: finer resolution at low end, min and max preserved",

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -108,7 +108,7 @@ func TestHistogramWithDoesNotMutateBase(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ExponentialBoundaries and preset variables
+// MakeExponentialHistogramBoundaries
 // ---------------------------------------------------------------------------
 
 func TestBoundaries(t *testing.T) {
@@ -118,24 +118,54 @@ func TestBoundaries(t *testing.T) {
 		want []float64
 	}{
 		{
-			name: "20-bucket latency range",
-			got:  ExponentialBoundaries(1, 60_000, 20),
-			want: []float64{1, 2, 3, 6, 10, 18, 32, 58, 103, 183, 327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000},
-		},
-		{
-			name: "5-bucket range",
-			got:  ExponentialBoundaries(10, 1000, 5),
-			want: []float64{10, 32, 100, 316, 1000},
-		},
-		{
-			name: "count less than 2 returns min and max",
-			got:  ExponentialBoundaries(1, 100, 1),
+			name: "count less than 2 returns [min, max]",
+			got:  MakeExponentialHistogramBoundaries(1, 100, 1, 0),
 			want: []float64{1, 100},
 		},
 		{
-			name: "PresetLatencyBoundariesMs",
-			got:  PresetLatencyBoundariesMs,
+			name: "count less than 2 ignores scaling factor",
+			got:  MakeExponentialHistogramBoundaries(1, 100, 1, 5),
+			want: []float64{1, 100},
+		},
+		{
+			name: "scaling factor 0 treated as 1 (no-op)",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 0),
+			want: []float64{10, 32, 100, 316, 1000},
+		},
+		{
+			name: "negative scaling factor treated as 1 (no-op)",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, -3),
+			want: []float64{10, 32, 100, 316, 1000},
+		},
+		{
+			name: "5 buckets, uniform log-spacing",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 1),
+			want: []float64{10, 32, 100, 316, 1000},
+		},
+		{
+			name: "15 buckets, uniform log-spacing",
+			got:  MakeExponentialHistogramBoundaries(1, 60_000, 15, 1),
 			want: []float64{1, 2, 5, 11, 23, 51, 112, 245, 537, 1179, 2588, 5679, 12461, 27344, 60000},
+		},
+		{
+			name: "20 buckets, uniform log-spacing",
+			got:  MakeExponentialHistogramBoundaries(1, 60_000, 20, 1),
+			want: []float64{1, 2, 3, 6, 10, 18, 32, 58, 103, 183, 327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000},
+		},
+		{
+			name: "scaling factor 2: finer resolution at low end, min and max preserved",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 2),
+			want: []float64{10, 13, 32, 133, 1000},
+		},
+		{
+			name: "scaling factor 3: even finer resolution at low end",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 3),
+			want: []float64{10, 11, 18, 70, 1000},
+		},
+		{
+			name: "scaling factor 5: extreme skewness, first intermediate bucket saturates to min",
+			got:  MakeExponentialHistogramBoundaries(10, 1000, 5, 5),
+			want: []float64{10, 10, 12, 30, 1000},
 		},
 	}
 
@@ -287,7 +317,8 @@ func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
 	reader := sdkMetric.NewManualReader()
 	ctx := ctatsCtx(t, reader)
 
-	Histogram[int64]("op.latency", WithBoundaries(PresetLatencyBoundariesMs...)).Record(ctx, 15_000)
+	boundaries := MakeExponentialHistogramBoundaries(1, 60_000, 15, 1)
+	Histogram[int64]("op.latency", WithBoundaries(boundaries...)).Record(ctx, 15_000)
 
 	dp := collectHistogram(t, reader, "op.latency")
 

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -108,94 +108,41 @@ func TestHistogramWithDoesNotMutateBase(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// ExponentialBoundaries
+// ExponentialBoundaries and preset variables
 // ---------------------------------------------------------------------------
 
-func TestExponentialBoundaries(t *testing.T) {
+func TestBoundaries(t *testing.T) {
 	testCases := []struct {
-		name    string
-		min     float64
-		max     float64
-		count   int
-		wantLen int
-		wantMin float64
-		wantMax float64
+		name string
+		got  []float64
+		want []float64
 	}{
 		{
-			name:    "standard 20-bucket latency range",
-			min:     1,
-			max:     60_000,
-			count:   20,
-			wantLen: 20,
-			wantMin: 1,
-			wantMax: 60_000,
+			name: "20-bucket latency range",
+			got:  ExponentialBoundaries(1, 60_000, 20),
+			want: []float64{1, 2, 3, 6, 10, 18, 32, 58, 103, 183, 327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000},
 		},
 		{
-			name:    "small count",
-			min:     10,
-			max:     1000,
-			count:   5,
-			wantLen: 5,
-			wantMin: 10,
-			wantMax: 1000,
+			name: "5-bucket range",
+			got:  ExponentialBoundaries(10, 1000, 5),
+			want: []float64{10, 32, 100, 316, 1000},
 		},
 		{
-			name:    "count less than 2 returns min and max",
-			min:     1,
-			max:     100,
-			count:   1,
-			wantLen: 2,
-			wantMin: 1,
-			wantMax: 100,
+			name: "count less than 2 returns min and max",
+			got:  ExponentialBoundaries(1, 100, 1),
+			want: []float64{1, 100},
+		},
+		{
+			name: "PresetLatencyBoundariesMs",
+			got:  PresetLatencyBoundariesMs,
+			want: []float64{1, 2, 5, 11, 23, 51, 112, 245, 537, 1179, 2588, 5679, 12461, 27344, 60000},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			got := ExponentialBoundaries(test.min, test.max, test.count)
-
-			require.Len(t, got, test.wantLen, "boundary count")
-			assert.Equal(t, test.wantMin, got[0], "first boundary must equal min")
-			assert.Equal(t, test.wantMax, got[len(got)-1], "last boundary must equal max")
-
-			for i := 1; i < len(got); i++ {
-				assert.Greater(t, got[i], got[i-1], "boundaries must be strictly increasing at index %d", i)
-			}
+			assert.Equal(t, test.want, test.got)
 		})
-	}
-}
-
-func TestExponentialBoundariesDefaultLatencyValues(t *testing.T) {
-	// Spot-check the documented example output for ExponentialBoundaries(1, 60_000, 20).
-	got := ExponentialBoundaries(1, 60_000, 20)
-
-	require.Len(t, got, 20)
-	assert.Equal(t, float64(1), got[0])
-	assert.Equal(t, float64(60_000), got[19])
-
-	// Mid-range spot checks.
-	assert.Equal(t, float64(10), got[4])
-	assert.Equal(t, float64(327), got[10])
-	assert.Equal(t, float64(10561), got[16])
-}
-
-// ---------------------------------------------------------------------------
-// PresetLatencyBoundariesMs
-// ---------------------------------------------------------------------------
-
-func TestPresetLatencyBoundariesMs(t *testing.T) {
-	assert.Len(t, PresetLatencyBoundariesMs, 20, "should have 20 buckets")
-	assert.Equal(t, float64(1), PresetLatencyBoundariesMs[0], "first boundary is 1 ms")
-	assert.Equal(t, float64(60_000), PresetLatencyBoundariesMs[19], "last boundary is 60,000 ms")
-
-	for i := 1; i < len(PresetLatencyBoundariesMs); i++ {
-		assert.Greater(
-			t,
-			PresetLatencyBoundariesMs[i],
-			PresetLatencyBoundariesMs[i-1],
-			"boundaries must be strictly increasing at index %d",
-			i,
-		)
 	}
 }
 
@@ -296,7 +243,7 @@ func collectHistogram(
 // TestRecordWithDefaultLatencyBoundaries records a 15,000 ms value through the
 // full ctats.Record path.
 //
-// 15,000 falls between bounds[16]=10,561 and bounds[17]=18,845 → bucket index 17.
+// 15,000 falls between bounds[12]=12,461 and bounds[13]=27,344 → bucket index 13.
 func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
 	reader := sdkMetric.NewManualReader()
 	ctx := ctatsCtx(t, reader)
@@ -308,8 +255,8 @@ func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
 	assert.Equal(t, float64(60_000), dp.Bounds[len(dp.Bounds)-1], "last boundary is 60,000 ms")
 	assert.Equal(t, uint64(0), dp.BucketCounts[len(dp.BucketCounts)-1], "no overflow")
 
-	// 15,000 ms sits between bounds[16]=10,561 and bounds[17]=18,845
-	assert.Equal(t, uint64(1), dp.BucketCounts[17], "15,000 ms lands in bucket 17 (10561–18845 ms)")
+	// 15,000 ms sits between bounds[12]=12,461 and bounds[13]=27,344
+	assert.Equal(t, uint64(1), dp.BucketCounts[13], "15,000 ms lands in bucket 13 (12461–27344 ms)")
 }
 
 // TestRecordDefaultOTelBoundariesOverflow shows that without WithBoundaries,

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -186,6 +186,45 @@ func TestHistogramNoBoundariesByDefault(t *testing.T) {
 	assert.Nil(t, h.boundaries, "no boundaries by default")
 }
 
+func TestHistogramFirstBoundariesWin(t *testing.T) {
+	first := []float64{1, 10, 100}
+	second := []float64{500, 1000, 5000}
+
+	testCases := []struct {
+		name  string
+		setup func(t *testing.T, ctx context.Context) context.Context
+	}{
+		{
+			name: "first via factory Record",
+			setup: func(t *testing.T, ctx context.Context) context.Context {
+				Histogram[int64]("first.wins", WithBoundaries(first...)).Record(ctx, 50)
+				return ctx
+			},
+		},
+		{
+			name: "first via RegisterHistogram",
+			setup: func(t *testing.T, ctx context.Context) context.Context {
+				ctx, err := RegisterHistogram(ctx, "first.wins", "", "", WithBoundaries(first...))
+				require.NoError(t, err)
+				return ctx
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			reader := sdkMetric.NewManualReader()
+			ctx := ctatsCtx(t, reader)
+			ctx = test.setup(t, ctx)
+
+			Histogram[int64]("first.wins", WithBoundaries(second...)).Record(ctx, 50)
+
+			dp := collectHistogram(t, reader, "first.wins")
+			assert.Equal(t, float64(100), dp.Bounds[len(dp.Bounds)-1], "second boundaries ignored, first wins")
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Record end-to-end with real OTel MeterProvider
 // ---------------------------------------------------------------------------

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -140,12 +140,18 @@ func TestBoundaries(t *testing.T) {
 		{
 			name: "15 buckets, uniform log-spacing",
 			got:  MakeExponentialHistogramBoundaries(1, 60_000, 15, 1),
-			want: []float64{1, 2, 5, 11, 23, 51, 112, 245, 537, 1179, 2588, 5679, 12461, 27344, 60000},
+			want: []float64{
+				1, 2, 5, 11, 23, 51, 112, 245,
+				537, 1179, 2588, 5679, 12461, 27344, 60000,
+			},
 		},
 		{
 			name: "20 buckets, uniform log-spacing",
 			got:  MakeExponentialHistogramBoundaries(1, 60_000, 20, 1),
-			want: []float64{1, 2, 3, 6, 10, 18, 32, 58, 103, 183, 327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000},
+			want: []float64{
+				1, 2, 3, 6, 10, 18, 32, 58, 103, 183,
+				327, 584, 1042, 1859, 3317, 5919, 10561, 18845, 33626, 60000,
+			},
 		},
 		{
 			name: "scaling factor 0.5: finer resolution at high end, min and max preserved",
@@ -241,6 +247,7 @@ func TestHistogramFirstBoundariesWin(t *testing.T) {
 			setup: func(t *testing.T, ctx context.Context) context.Context {
 				ctx, err := RegisterHistogram(ctx, "first.wins", "", "", WithBoundaries(first...))
 				require.NoError(t, err)
+
 				return ctx
 			},
 		},
@@ -255,7 +262,10 @@ func TestHistogramFirstBoundariesWin(t *testing.T) {
 			Histogram[int64]("first.wins", WithBoundaries(second...)).Record(ctx, 50)
 
 			dp := collectHistogram(t, reader, "first.wins")
-			assert.Equal(t, float64(100), dp.Bounds[len(dp.Bounds)-1], "second boundaries ignored, first wins")
+			assert.Equal(
+				t, float64(100), dp.Bounds[len(dp.Bounds)-1],
+				"second boundaries ignored, first wins",
+			)
 		})
 	}
 }
@@ -270,6 +280,7 @@ func ctatsCtx(t *testing.T, reader *sdkMetric.ManualReader) context.Context {
 	t.Helper()
 
 	mp := sdkMetric.NewMeterProvider(sdkMetric.WithReader(reader))
+
 	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
 
 	otelClient := &node.OTELClient{
@@ -304,6 +315,7 @@ func collectHistogram(
 				h, ok := m.Data.(metricdata.Histogram[float64])
 				require.True(t, ok, "metric %q is not a Histogram[float64]", name)
 				require.NotEmpty(t, h.DataPoints)
+
 				return h.DataPoints[0]
 			}
 		}
@@ -327,11 +339,17 @@ func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
 
 	dp := collectHistogram(t, reader, "op.latency")
 
-	assert.Equal(t, float64(60_000), dp.Bounds[len(dp.Bounds)-1], "last boundary is 60,000 ms")
+	assert.Equal(
+		t, float64(60_000), dp.Bounds[len(dp.Bounds)-1],
+		"last boundary is 60,000 ms",
+	)
 	assert.Equal(t, uint64(0), dp.BucketCounts[len(dp.BucketCounts)-1], "no overflow")
 
 	// 15,000 ms sits between bounds[12]=12,461 and bounds[13]=27,344
-	assert.Equal(t, uint64(1), dp.BucketCounts[13], "15,000 ms lands in bucket 13 (12461–27344 ms)")
+	assert.Equal(
+		t, uint64(1), dp.BucketCounts[13],
+		"15,000 ms lands in bucket 13 (12461–27344 ms)",
+	)
 }
 
 // TestRecordDefaultOTelBoundariesOverflow shows that without WithBoundaries,
@@ -344,6 +362,12 @@ func TestRecordDefaultOTelBoundariesOverflow(t *testing.T) {
 
 	dp := collectHistogram(t, reader, "op.latency.default")
 
-	assert.Equal(t, float64(10_000), dp.Bounds[len(dp.Bounds)-1], "default ceiling is 10,000 ms")
-	assert.Equal(t, uint64(1), dp.BucketCounts[len(dp.BucketCounts)-1], "15,000 ms overflows to +Inf")
+	assert.Equal(
+		t, float64(10_000), dp.Bounds[len(dp.Bounds)-1],
+		"default ceiling is 10,000 ms",
+	)
+	assert.Equal(
+		t, uint64(1), dp.BucketCounts[len(dp.BucketCounts)-1],
+		"15,000 ms overflows to +Inf",
+	)
 }

--- a/ctats/histogram_test.go
+++ b/ctats/histogram_test.go
@@ -180,19 +180,19 @@ func TestExponentialBoundariesDefaultLatencyValues(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// DefaultLatencyBoundariesMs
+// PresetLatencyBoundariesMs
 // ---------------------------------------------------------------------------
 
-func TestDefaultLatencyBoundariesMs(t *testing.T) {
-	assert.Len(t, DefaultLatencyBoundariesMs, 20, "should have 20 buckets")
-	assert.Equal(t, float64(1), DefaultLatencyBoundariesMs[0], "first boundary is 1 ms")
-	assert.Equal(t, float64(60_000), DefaultLatencyBoundariesMs[19], "last boundary is 60,000 ms")
+func TestPresetLatencyBoundariesMs(t *testing.T) {
+	assert.Len(t, PresetLatencyBoundariesMs, 20, "should have 20 buckets")
+	assert.Equal(t, float64(1), PresetLatencyBoundariesMs[0], "first boundary is 1 ms")
+	assert.Equal(t, float64(60_000), PresetLatencyBoundariesMs[19], "last boundary is 60,000 ms")
 
-	for i := 1; i < len(DefaultLatencyBoundariesMs); i++ {
+	for i := 1; i < len(PresetLatencyBoundariesMs); i++ {
 		assert.Greater(
 			t,
-			DefaultLatencyBoundariesMs[i],
-			DefaultLatencyBoundariesMs[i-1],
+			PresetLatencyBoundariesMs[i],
+			PresetLatencyBoundariesMs[i-1],
 			"boundaries must be strictly increasing at index %d",
 			i,
 		)
@@ -301,7 +301,7 @@ func TestRecordWithDefaultLatencyBoundaries(t *testing.T) {
 	reader := sdkMetric.NewManualReader()
 	ctx := ctatsCtx(t, reader)
 
-	Histogram[int64]("op.latency", WithBoundaries(DefaultLatencyBoundariesMs...)).Record(ctx, 15_000)
+	Histogram[int64]("op.latency", WithBoundaries(PresetLatencyBoundariesMs...)).Record(ctx, 15_000)
 
 	dp := collectHistogram(t, reader, "op.latency")
 


### PR DESCRIPTION
The OTel Go SDK uses explicit bucket boundaries that top out at **10,000**. Any observation above that lands in the `+Inf` overflow bucket, and since Kibana's `percentile()` uses linear interpolation within buckets it silently maxes out at 10,000. Customizing the bucket boundaries is needed to measure latencies above 10,000

The OTel mechanism is explicit bucket boundaries via `metric.WithExplicitBucketBoundaries` at instrument creation time — per-instrument, not a global MeterProvider view.

**Changes:**
- `ExponentialBoundaries(min, max, count)` — logarithmically-spaced buckets mirroring Prometheus's `ExponentialBucketsRange`
- `DefaultLatencyBoundariesMs` — 20 buckets from 1–60,000
- `WithBoundaries(...) HistogramOption` on `Histogram[N]` and `RegisterHistogram`
- Tests covering the math, option propagation, and end-to-end `Record` bucket placement via a `ManualReader`-backed OTel context
