### PR TITLE
clutel: fix Inherit dropping the OTEL trace context onto detached contexts

### DIFF
--- a/clutel/clutel.go
+++ b/clutel/clutel.go
@@ -85,9 +85,14 @@ func Inherit(
 
 	to = node.EmbedInCtx(to, toNode)
 
+	// Carry the OTEL trace context (and baggage) from `from` onto `to`:
+	// serialize it out of `from` into the carrier, then extract it into `to`,
+	// capturing the returned context. The previous order (ReceiveTrace(from)
+	// then InjectTrace(to)) round-tripped through an empty carrier and dropped
+	// both return values, so no trace context was ever propagated.
 	details := map[string]string{}
-	ReceiveTrace(from, details)
-	InjectTrace(to, details)
+	InjectTrace(from, details)
+	to = ReceiveTrace(to, details)
 
 	return to
 }

--- a/clutel/clutel_test.go
+++ b/clutel/clutel_test.go
@@ -799,3 +799,35 @@ func TestInherit(t *testing.T) {
 		})
 	}
 }
+
+// TestInherit_PropagatesTraceContext guards the trace-propagation half of
+// Inherit. The surrounding TestInherit only asserts the inherited OTEL client
+// (n.OTEL.ServiceName); it never inspects the span, so a regression in trace
+// propagation would go unnoticed. This detaches onto context.Background() (as a
+// fire-and-forget goroutine would) and asserts the originating trace.id - and
+// baggage - survive.
+func TestInherit_PropagatesTraceContext(t *testing.T) {
+	// Init registers the composite TraceContext+Baggage propagator and an OTEL
+	// client on the context (so Inherit's fromNode.OTEL != nil guard passes).
+	from, err := clutel.Init(t.Context(), "test", clutel.NewConfig(nil, "localhost:4317"))
+	require.NoError(t, err)
+
+	from = clutel.StartSpan(from, "originating-span")
+	defer clutel.EndSpan(from)
+
+	from, err = clutel.AddBaggage(from, "tenant", "acme")
+	require.NoError(t, err)
+
+	want := clutel.GetSpan(from).SpanContext().TraceID()
+	require.True(t, want.IsValid(),
+		"test setup: originating span must have a valid trace id")
+
+	// Detach onto a fresh background context, severed from cancellation.
+	detached := clutel.Inherit(from, context.Background(), true)
+
+	got := trace.SpanContextFromContext(detached).TraceID()
+	assert.Equal(t, want.String(), got.String(),
+		"trace.id must survive Inherit onto context.Background()")
+	assert.Equal(t, "acme", baggage.FromContext(detached).Member("tenant").Value(),
+		"baggage must survive Inherit onto context.Background()")
+}


### PR DESCRIPTION
## What

`clutel.Inherit` (and therefore `clues.Inherit`) does not propagate the OTEL trace context from `from` to `to`. Its trace block:

```go
details := map[string]string{}
ReceiveTrace(from, details)
InjectTrace(to, details)
```

has two defects:

1. **Reversed order** — it extracts *out of* the empty `details` carrier (`ReceiveTrace(from, …)`) and then serializes `to`'s span *into* the carrier (`InjectTrace(to, …)`). The span on `from` is never written into the carrier.
2. **Discarded return values** — `ReceiveTrace` returns the context carrying the extracted trace, but the result is thrown away, so `to` never gains it.

Net effect: detaching a fire-and-forget goroutine via `Inherit(ctx, context.Background(), …)` silently loses the originating `trace.id` (and baggage), breaking log/trace correlation for async work.

## Fix

Serialize `from` into the carrier, then capture the context returned by extracting into `to`:

```go
details := map[string]string{}
InjectTrace(from, details)
to = ReceiveTrace(to, details)
```

Because `clutel.Init` registers a composite `TraceContext{} + Baggage{}` propagator, this restores both the trace context and baggage.

## Tests

The existing `TestInherit` asserts only the inherited OTEL client (`n.OTEL.ServiceName`) and never inspects the span, so this was uncovered. Adds `TestInherit_PropagatesTraceContext`, which detaches onto `context.Background()` and asserts the originating `trace.id` and baggage survive. Verified it fails on the old order and passes on the fix.